### PR TITLE
Stop caching empty encryption keys

### DIFF
--- a/controllers/encryption.go
+++ b/controllers/encryption.go
@@ -34,12 +34,22 @@ func (r *ConfigurationPolicyReconciler) getEncryptionKey(namespace string) (*cac
 		return nil, fmt.Errorf("failed to get the encryption key from Secret %s/%s: %w", namespace, secretName, err)
 	}
 
-	key := &cachedEncryptionKey{
-		key:         encryptionSecret.Data["key"],
-		previousKey: encryptionSecret.Data["previousKey"],
+	var key []byte
+	if len(encryptionSecret.Data["key"]) > 0 {
+		key = encryptionSecret.Data["key"]
 	}
 
-	return key, nil
+	var previousKey []byte
+	if len(encryptionSecret.Data["previousKey"]) > 0 {
+		previousKey = encryptionSecret.Data["previousKey"]
+	}
+
+	cachedKey := &cachedEncryptionKey{
+		key:         key,
+		previousKey: previousKey,
+	}
+
+	return cachedKey, nil
 }
 
 // getEncryptionConfig returns the encryption config for decrypting values that were encrypted using Hub templates.

--- a/controllers/encryption_test.go
+++ b/controllers/encryption_test.go
@@ -195,6 +195,30 @@ func TestGetEncryptionConfigForceRefresh(t *testing.T) {
 	Expect(config.AESKey).ToNot(Equal(key))
 }
 
+func TestGetEncryptionKeyEmptySecret(t *testing.T) {
+	t.Parallel()
+	RegisterFailHandler(Fail)
+
+	encryptionSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: clusterName,
+		},
+		Data: map[string][]byte{
+			"key":         {},
+			"previousKey": {},
+		},
+	}
+	client := fake.NewClientBuilder().WithObjects(encryptionSecret).Build()
+
+	r := ConfigurationPolicyReconciler{Client: client, DecryptionConcurrency: 5}
+	cachedEncryptionKey, err := r.getEncryptionKey(clusterName)
+
+	Expect(err).To(BeNil())
+	Expect(cachedEncryptionKey.key).To(BeNil())
+	Expect(cachedEncryptionKey.previousKey).To(BeNil())
+}
+
 func TestUsesEncryption(t *testing.T) {
 	t.Parallel()
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
If the Secret has an empty value as the previous key, it shouldn't be cached
since go-template-utils will see it as an empty byte slice instead of a
nil byte slice and error.