### PR TITLE
Add a configurable evaluation interval for configuration policies

### DIFF
--- a/controllers/configurationpolicy_controller_test.go
+++ b/controllers/configurationpolicy_controller_test.go
@@ -18,26 +18,26 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	policiesv1alpha1 "github.com/stolostron/config-policy-controller/api/v1"
+	policyv1 "github.com/stolostron/config-policy-controller/api/v1"
 	"github.com/stolostron/config-policy-controller/pkg/common"
 )
 
 func TestReconcile(t *testing.T) {
 	name := "foo"
 	namespace := "default"
-	instance := &policiesv1alpha1.ConfigurationPolicy{
+	instance := &policyv1.ConfigurationPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "default",
 		},
-		Spec: policiesv1alpha1.ConfigurationPolicySpec{
+		Spec: policyv1.ConfigurationPolicySpec{
 			Severity: "low",
-			NamespaceSelector: policiesv1alpha1.Target{
-				Include: []policiesv1alpha1.NonEmptyString{"default", "kube-*"},
-				Exclude: []policiesv1alpha1.NonEmptyString{"kube-system"},
+			NamespaceSelector: policyv1.Target{
+				Include: []policyv1.NonEmptyString{"default", "kube-*"},
+				Exclude: []policyv1.NonEmptyString{"kube-system"},
 			},
 			RemediationAction: "inform",
-			ObjectTemplates: []*policiesv1alpha1.ObjectTemplate{
+			ObjectTemplates: []*policyv1.ObjectTemplate{
 				{
 					ComplianceType:   "musthave",
 					ObjectDefinition: runtime.RawExtension{},
@@ -50,7 +50,7 @@ func TestReconcile(t *testing.T) {
 	objs := []runtime.Object{instance}
 	// Register operator types with the runtime scheme.
 	s := scheme.Scheme
-	s.AddKnownTypes(policiesv1alpha1.GroupVersion, instance)
+	s.AddKnownTypes(policyv1.GroupVersion, instance)
 
 	// Create a fake client to mock API calls.
 	//nolint:staticcheck
@@ -229,17 +229,17 @@ func TestCompareLists(t *testing.T) {
 }
 
 func TestConvertPolicyStatusToString(t *testing.T) {
-	compliantDetail := policiesv1alpha1.TemplateStatus{
-		ComplianceState: policiesv1alpha1.NonCompliant,
-		Conditions:      []policiesv1alpha1.Condition{},
+	compliantDetail := policyv1.TemplateStatus{
+		ComplianceState: policyv1.NonCompliant,
+		Conditions:      []policyv1.Condition{},
 	}
-	compliantDetails := []policiesv1alpha1.TemplateStatus{}
+	compliantDetails := []policyv1.TemplateStatus{}
 
 	for i := 0; i < 3; i++ {
 		compliantDetails = append(compliantDetails, compliantDetail)
 	}
 
-	samplePolicyStatus := policiesv1alpha1.ConfigurationPolicyStatus{
+	samplePolicyStatus := policyv1.ConfigurationPolicyStatus{
 		ComplianceState:   "Compliant",
 		CompliancyDetails: compliantDetails,
 	}
@@ -317,7 +317,7 @@ func TestMerge(t *testing.T) {
 
 func TestAddRelatedObject(t *testing.T) {
 	compliant := true
-	rsrc := policiesv1alpha1.SchemeBuilder.GroupVersion.WithResource("ConfigurationPolicy")
+	rsrc := policyv1.SchemeBuilder.GroupVersion.WithResource("ConfigurationPolicy")
 	namespace := "default"
 	namespaced := true
 	name := "foo"
@@ -326,7 +326,7 @@ func TestAddRelatedObject(t *testing.T) {
 	related := relatedList[0]
 
 	// get the related object and validate what we added is in the status
-	assert.True(t, related.Compliant == string(policiesv1alpha1.Compliant))
+	assert.True(t, related.Compliant == string(policyv1.Compliant))
 	assert.True(t, related.Reason == "reason")
 	assert.True(t, related.Object.APIVersion == rsrc.GroupVersion().String())
 	assert.True(t, related.Object.Kind == rsrc.Resource)
@@ -340,7 +340,7 @@ func TestAddRelatedObject(t *testing.T) {
 	related = relatedList[0]
 
 	assert.True(t, len(relatedList) == 1)
-	assert.True(t, related.Compliant == string(policiesv1alpha1.NonCompliant))
+	assert.True(t, related.Compliant == string(policyv1.NonCompliant))
 	assert.True(t, related.Reason == "new")
 
 	// add a new related object and make sure the entry is appended
@@ -356,19 +356,19 @@ func TestAddRelatedObject(t *testing.T) {
 }
 
 func TestSortRelatedObjectsAndUpdate(t *testing.T) {
-	policy := &policiesv1alpha1.ConfigurationPolicy{
+	policy := &policyv1.ConfigurationPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "default",
 		},
-		Spec: policiesv1alpha1.ConfigurationPolicySpec{
+		Spec: policyv1.ConfigurationPolicySpec{
 			Severity: "low",
-			NamespaceSelector: policiesv1alpha1.Target{
-				Include: []policiesv1alpha1.NonEmptyString{"default", "kube-*"},
-				Exclude: []policiesv1alpha1.NonEmptyString{"kube-system"},
+			NamespaceSelector: policyv1.Target{
+				Include: []policyv1.NonEmptyString{"default", "kube-*"},
+				Exclude: []policyv1.NonEmptyString{"kube-system"},
 			},
 			RemediationAction: "inform",
-			ObjectTemplates: []*policiesv1alpha1.ObjectTemplate{
+			ObjectTemplates: []*policyv1.ObjectTemplate{
 				{
 					ComplianceType:   "musthave",
 					ObjectDefinition: runtime.RawExtension{},
@@ -376,7 +376,7 @@ func TestSortRelatedObjectsAndUpdate(t *testing.T) {
 			},
 		},
 	}
-	rsrc := policiesv1alpha1.SchemeBuilder.GroupVersion.WithResource("ConfigurationPolicy")
+	rsrc := policyv1.SchemeBuilder.GroupVersion.WithResource("ConfigurationPolicy")
 	name := "foo"
 	relatedList := addRelatedObjects(true, rsrc, "default", true, []string{name}, "reason")
 
@@ -384,7 +384,7 @@ func TestSortRelatedObjectsAndUpdate(t *testing.T) {
 	name = "bar"
 	relatedList = append(relatedList, addRelatedObjects(true, rsrc, "default", true, []string{name}, "reason")...)
 
-	empty := []policiesv1alpha1.RelatedObject{}
+	empty := []policyv1.RelatedObject{}
 
 	sortRelatedObjectsAndUpdate(policy, relatedList, empty)
 	assert.True(t, relatedList[0].Object.Metadata.Name == "bar")
@@ -406,18 +406,18 @@ func TestSortRelatedObjectsAndUpdate(t *testing.T) {
 }
 
 func TestCreateInformStatus(t *testing.T) {
-	policy := &policiesv1alpha1.ConfigurationPolicy{
+	policy := &policyv1.ConfigurationPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "default",
 		},
-		Spec: policiesv1alpha1.ConfigurationPolicySpec{
+		Spec: policyv1.ConfigurationPolicySpec{
 			Severity: "low",
-			NamespaceSelector: policiesv1alpha1.Target{
-				Include: []policiesv1alpha1.NonEmptyString{"test1", "test2"},
+			NamespaceSelector: policyv1.Target{
+				Include: []policyv1.NonEmptyString{"test1", "test2"},
 			},
 			RemediationAction: "inform",
-			ObjectTemplates: []*policiesv1alpha1.ObjectTemplate{
+			ObjectTemplates: []*policyv1.ObjectTemplate{
 				{
 					ComplianceType:   "musthave",
 					ObjectDefinition: runtime.RawExtension{},
@@ -445,7 +445,7 @@ func TestCreateInformStatus(t *testing.T) {
 	// Test 1 NonCompliant resource
 	createInformStatus(!mustNotHave, numCompliant, numNonCompliant,
 		compliantObjects, nonCompliantObjects, policy, objData)
-	assert.True(t, policy.Status.CompliancyDetails[0].ComplianceState == policiesv1alpha1.NonCompliant)
+	assert.True(t, policy.Status.CompliancyDetails[0].ComplianceState == policyv1.NonCompliant)
 
 	nonCompliantObjects["test2"] = map[string]interface{}{
 		"names":  []string{"myobject"},
@@ -456,7 +456,7 @@ func TestCreateInformStatus(t *testing.T) {
 	// Test 2 NonCompliant resources
 	createInformStatus(!mustNotHave, numCompliant, numNonCompliant,
 		compliantObjects, nonCompliantObjects, policy, objData)
-	assert.True(t, policy.Status.CompliancyDetails[0].ComplianceState == policiesv1alpha1.NonCompliant)
+	assert.True(t, policy.Status.CompliancyDetails[0].ComplianceState == policyv1.NonCompliant)
 
 	delete(nonCompliantObjects, "test1")
 	delete(nonCompliantObjects, "test2")
@@ -465,7 +465,7 @@ func TestCreateInformStatus(t *testing.T) {
 	numNonCompliant = 0
 	createInformStatus(!mustNotHave, numCompliant, numNonCompliant,
 		compliantObjects, nonCompliantObjects, policy, objData)
-	assert.True(t, policy.Status.CompliancyDetails[0].ComplianceState == policiesv1alpha1.NonCompliant)
+	assert.True(t, policy.Status.CompliancyDetails[0].ComplianceState == policyv1.NonCompliant)
 
 	compliantObjects["test1"] = map[string]interface{}{
 		"names":  []string{"myobject"},
@@ -481,7 +481,7 @@ func TestCreateInformStatus(t *testing.T) {
 	// Test 1 compliant and 1 noncompliant resource  NOTE: This use case is the new behavior change!
 	createInformStatus(!mustNotHave, numCompliant, numNonCompliant,
 		compliantObjects, nonCompliantObjects, policy, objData)
-	assert.True(t, policy.Status.CompliancyDetails[0].ComplianceState == policiesv1alpha1.NonCompliant)
+	assert.True(t, policy.Status.CompliancyDetails[0].ComplianceState == policyv1.NonCompliant)
 
 	compliantObjects["test2"] = map[string]interface{}{
 		"names":  []string{"myobject"},
@@ -495,5 +495,5 @@ func TestCreateInformStatus(t *testing.T) {
 	// Test 2 compliant resources
 	createInformStatus(!mustNotHave, numCompliant, numNonCompliant,
 		compliantObjects, nonCompliantObjects, policy, objData)
-	assert.True(t, policy.Status.CompliancyDetails[0].ComplianceState == policiesv1alpha1.Compliant)
+	assert.True(t, policy.Status.CompliancyDetails[0].ComplianceState == policyv1.Compliant)
 }

--- a/controllers/configurationpolicy_utils_test.go
+++ b/controllers/configurationpolicy_utils_test.go
@@ -1,9 +1,13 @@
 package controllers
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	policyv1 "github.com/stolostron/config-policy-controller/api/v1"
 )
 
 func TestFormatTemplateAnnotation(t *testing.T) {
@@ -52,4 +56,48 @@ func TestFormatTemplateStringAnnotation(t *testing.T) {
 
 	policyTemplateFormatted := formatMetadata(policyTemplate)
 	assert.Equal(t, policyTemplateFormatted["annotations"], "not-an-annotation")
+}
+
+func TestAddConditionToStatusNeverEvalInterval(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		compliancy         policyv1.ComplianceState
+		evaluationInterval policyv1.EvaluationInterval
+	}{
+		{policyv1.Compliant, policyv1.EvaluationInterval{Compliant: "never"}},
+		{policyv1.NonCompliant, policyv1.EvaluationInterval{NonCompliant: "never"}},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(
+			fmt.Sprintf("compliance=%s", test.compliancy),
+			func(t *testing.T) {
+				t.Parallel()
+
+				policy := &policyv1.ConfigurationPolicy{
+					Spec: policyv1.ConfigurationPolicySpec{
+						EvaluationInterval: test.evaluationInterval,
+					},
+				}
+
+				addConditionToStatus(policy, 0, test.compliancy == policyv1.Compliant, "Some reason", "Some message")
+
+				details := policy.Status.CompliancyDetails
+				assert.Equal(t, len(details), 1)
+
+				detail := details[0]
+				conditions := detail.Conditions
+				assert.Equal(t, len(conditions), 1)
+
+				condition := conditions[0]
+				lowercaseCompliance := strings.ToLower(string(test.compliancy))
+				expectedMsg := `Some message. This policy will not be evaluated again due to ` +
+					fmt.Sprintf(`spec.evaluationInterval.%s being set to "never".`, lowercaseCompliance)
+
+				assert.Equal(t, condition.Message, expectedMsg)
+			},
+		)
+	}
 }

--- a/deploy/crds/policy.open-cluster-management.io_configurationpolicies.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_configurationpolicies.yaml
@@ -37,6 +37,23 @@ spec:
           spec:
             description: ConfigurationPolicySpec defines the desired state of ConfigurationPolicy
             properties:
+              evaluationInterval:
+                description: Configures the minimum elapsed time before a ConfigurationPolicy
+                  is reevaluated
+                properties:
+                  compliant:
+                    description: The minimum elapsed time before a ConfigurationPolicy
+                      is reevaluated when in the compliant state. Set this to "never"
+                      to disable reevaluation when in the compliant state.
+                    pattern: ^(?:(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))|never)+$
+                    type: string
+                  noncompliant:
+                    description: The minimum elapsed time before a ConfigurationPolicy
+                      is reevaluated when in the noncompliant state. Set this to "never"
+                      to disable reevaluation when in the noncompliant state.
+                    pattern: ^(?:(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))|never)+$
+                    type: string
+                type: object
               labelSelector:
                 additionalProperties:
                   type: string
@@ -165,7 +182,17 @@ spec:
               compliant:
                 description: ComplianceState shows the state of enforcement
                 type: string
+              lastEvaluated:
+                description: An ISO-8601 timestamp of the last time the policy was
+                  evaluated
+                type: string
+              lastEvaluatedGeneration:
+                description: The generation of the ConfigurationPolicy object when
+                  it was last evaluated
+                format: int64
+                type: integer
               relatedObjects:
+                description: List of resources processed by the policy
                 items:
                   description: RelatedObject is the list of objects matched by this
                     Policy resource.

--- a/test/e2e/case17_evaluation_interval_test.go
+++ b/test/e2e/case17_evaluation_interval_test.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2022 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/stolostron/config-policy-controller/test/utils"
+)
+
+const (
+	case17policy               = "../resources/case17_evaluation_interval/policy.yaml"
+	case17policyName           = "policy-c17-create-ns"
+	case17policyNever          = "../resources/case17_evaluation_interval/policy-never-reevaluate.yaml"
+	case17policyNeverName      = "policy-c17-create-ns-never"
+	case17CreatedNamespaceName = "case17-test-never"
+)
+
+var _ = Describe("Test evaluation interval", func() {
+	It("Verifies that status.lastEvaluated is properly set", func() {
+		By("Creating " + case17policyName + " on the managed cluster")
+		utils.Kubectl("apply", "-f", case17policy, "-n", testNamespace)
+		plc := utils.GetWithTimeout(
+			clientManagedDynamic, gvrConfigPolicy, case17policyName, testNamespace, true, defaultTimeoutSeconds,
+		)
+		Expect(plc).NotTo(BeNil())
+
+		By("Getting status.lastEvaluated")
+		var managedPlc *unstructured.Unstructured
+
+		Eventually(func() interface{} {
+			managedPlc = utils.GetWithTimeout(
+				clientManagedDynamic, gvrConfigPolicy, case17policyName, testNamespace, true, defaultTimeoutSeconds,
+			)
+
+			lastEvaluated, _ := utils.GetLastEvaluated(managedPlc)
+
+			return lastEvaluated
+		}, defaultTimeoutSeconds, 1).ShouldNot(Equal(""))
+
+		lastEvaluated, lastEvaluatedGeneration := utils.GetLastEvaluated(managedPlc)
+		Expect(lastEvaluatedGeneration).To(Equal(managedPlc.GetGeneration()))
+
+		lastEvaluatedParsed, err := time.Parse(time.RFC3339, lastEvaluated)
+		Expect(err).To(BeNil())
+
+		By("Waiting for status.lastEvaluated to refresh")
+		Eventually(func() interface{} {
+			managedPlc = utils.GetWithTimeout(
+				clientManagedDynamic, gvrConfigPolicy, case17policyName, testNamespace, true, defaultTimeoutSeconds,
+			)
+
+			lastEvalRefreshed, _ := utils.GetLastEvaluated(managedPlc)
+
+			return lastEvalRefreshed
+		}, defaultTimeoutSeconds, 1).ShouldNot(Equal(lastEvaluated))
+
+		lastEvalRefreshed, lastEvalGenerationRefreshed := utils.GetLastEvaluated(managedPlc)
+		Expect(lastEvalGenerationRefreshed).To(Equal(lastEvaluatedGeneration))
+
+		lastEvalRefreshedParsed, err := time.Parse(time.RFC3339, lastEvalRefreshed)
+		Expect(err).To(BeNil())
+
+		Expect(lastEvaluatedParsed.Before(lastEvalRefreshedParsed)).To(BeTrue())
+	})
+
+	It("Verifies that a compliant policy is not reevaluated when set to never", func() {
+		By("Creating " + case17policyNeverName + " on the managed cluster")
+		utils.Kubectl("apply", "-f", case17policyNever, "-n", testNamespace)
+		plc := utils.GetWithTimeout(
+			clientManagedDynamic, gvrConfigPolicy, case17policyNeverName, testNamespace, true, defaultTimeoutSeconds,
+		)
+		Expect(plc).NotTo(BeNil())
+
+		By("Getting status.lastEvaluated")
+		var managedPlc *unstructured.Unstructured
+
+		Eventually(func() interface{} {
+			managedPlc = utils.GetWithTimeout(
+				clientManagedDynamic,
+				gvrConfigPolicy,
+				case17policyNeverName,
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
+
+			return utils.GetComplianceState(managedPlc)
+		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+
+		lastEvaluated, _ := utils.GetLastEvaluated(managedPlc)
+		_, err := time.Parse(time.RFC3339, lastEvaluated)
+		Expect(err).To(BeNil())
+
+		By("Verifying that compliance message mentions it won't be reevaluated")
+		msg, ok := utils.GetStatusMessage(managedPlc).(string)
+		Expect(ok).To(BeTrue())
+
+		expectedSuffix := `. This policy will not be evaluated again due to spec.evaluationInterval.compliant being ` +
+			`set to "never".`
+		Expect(strings.HasSuffix(msg, expectedSuffix)).To(BeTrue())
+
+		By("Verifying that status.lastEvaluated will not change after waiting 15 seconds")
+		time.Sleep(15 * time.Second)
+
+		managedPlc = utils.GetWithTimeout(
+			clientManagedDynamic, gvrConfigPolicy, case17policyNeverName, testNamespace, true, defaultTimeoutSeconds,
+		)
+		lastEvalRefreshed, _ := utils.GetLastEvaluated(managedPlc)
+		Expect(lastEvalRefreshed).To(Equal(lastEvaluated))
+	})
+
+	It("Cleans up", func() {
+		utils.Kubectl("delete", "-f", case17policy, "-n", testNamespace)
+		utils.Kubectl("delete", "-f", case17policyNever, "-n", testNamespace)
+		err := clientManaged.CoreV1().Namespaces().Delete(
+			context.TODO(), case17CreatedNamespaceName, v1.DeleteOptions{},
+		)
+		if !k8serrors.IsNotFound(err) {
+			Expect(err).To(BeNil())
+		}
+	})
+})

--- a/test/resources/case17_evaluation_interval/policy-never-reevaluate.yaml
+++ b/test/resources/case17_evaluation_interval/policy-never-reevaluate.yaml
@@ -1,0 +1,15 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-c17-create-ns-never
+spec:
+  evaluationInterval:
+    compliant: never
+  remediationAction: enforce
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        kind: Namespace
+        apiVersion: v1
+        metadata:
+          name: case17-test-never

--- a/test/resources/case17_evaluation_interval/policy.yaml
+++ b/test/resources/case17_evaluation_interval/policy.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-c17-create-ns
+spec:
+  remediationAction: inform
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        kind: Namespace
+        apiVersion: v1
+        metadata:
+          name: case17-test

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -221,3 +221,24 @@ func GetFieldFromSecret(secret *unstructured.Unstructured, field string) (result
 
 	return nil
 }
+
+// GetLastEvaluated parses the configuration policy and returns the status.lastEvaluated and
+// status.lastEvaluatedGeneration fields. If they are not set, then default null values are returned.
+func GetLastEvaluated(configPolicy *unstructured.Unstructured) (string, int64) {
+	status, ok := configPolicy.Object["status"].(map[string]interface{})
+	if !ok {
+		return "", 0
+	}
+
+	lastEvaluatedGeneration, ok := status["lastEvaluatedGeneration"].(int64)
+	if !ok {
+		return "", 0
+	}
+
+	lastEvaluated, ok := status["lastEvaluated"].(string)
+	if !ok {
+		return "", lastEvaluatedGeneration
+	}
+
+	return lastEvaluated, lastEvaluatedGeneration
+}


### PR DESCRIPTION
This adds the field `spec.evaluationInterval` which is a map that
accepts the keys `compliant` and `noncompliant`. Each value is a
duration for the minimum wait time between policy evaluations. The
values can also be set to `never` to disable evaluating the policy
entirely after a certain compliance state is reached. In this case, the
compliance message mentions that it will not be reevaluated.

On the technical implementation side, two new status fields are added.
The first is `status.lastEvaluated` which is a RFC3339/ISO-8601
formatted timestamp. This keeps track of when the policy was last
evaluated for the controller to know when the next evaluation should
take place. It is also useful information for the user.

The second status field that is added is
`status.lastEvaluatedGeneration`, which is the generation of the
`ConfigurationPolicy` object when the policy was last evaluated. This is
for the controller to know when to trigger an immediate evaluation when
the `ConfigurationPolicy` object's `spec` is updated.

Because these two status fields need to be set on every evaluation, the
status is always updated per evaluation, however, an event is not sent
when it's just these two status fields that were updated.

Resolves:
https://github.com/stolostron/backlog/issues/20006