### PR TITLE
Send a parent status update event only when the status changed

### DIFF
--- a/test/resources/case17_evaluation_interval/parent-policy.yaml
+++ b/test/resources/case17_evaluation_interval/parent-policy.yaml
@@ -1,0 +1,24 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: parent-policy-c17-create-ns
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-c17-create-ns-never
+        spec:
+          evaluationInterval:
+            compliant: never
+          remediationAction: enforce
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                kind: Namespace
+                apiVersion: v1
+                metadata:
+                  name: case17-test-never

--- a/test/resources/case17_evaluation_interval/policy.yaml
+++ b/test/resources/case17_evaluation_interval/policy.yaml
@@ -2,6 +2,11 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
   name: policy-c17-create-ns
+  ownerReferences:
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      name: parent-policy-c17-create-ns
+      uid: 12345678-90ab-cdef-1234-567890abcdef # must be replaced before creation
 spec:
   remediationAction: inform
   object-templates:


### PR DESCRIPTION
An oversight in #235 made it so that a parent policy status update event
was sent every time the policy was evaluated. This reverts some of the
status update tracking removal in that PR.

Refers:
https://github.com/stolostron/backlog/issues/20323