### PR TITLE
Configure the event recorder to not unnecessarily drop or alter events

### DIFF
--- a/main.go
+++ b/main.go
@@ -124,6 +124,8 @@ func main() {
 		// different messages if a large amount of events for that policy are sent in a short time.
 		EventBroadcaster: record.NewBroadcasterWithCorrelatorOptions(
 			record.CorrelatorOptions{
+				// This essentially disables event aggregation of the same events but with different messages.
+				MaxIntervalInSeconds: 1,
 				// This is the default spam key function except it adds the reason and message as well.
 				// https://github.com/kubernetes/client-go/blob/v0.23.3/tools/record/events_cache.go#L70-L82
 				SpamKeyFunc: func(event *corev1.Event) string {


### PR DESCRIPTION
The event recorder has rate limiting in order to prevent multiple
"duplicate" events from being sent in a short time. By default, the
"key" that it uses to determine if an event is a duplicate excludes the
reason and message of the event. This commit adds the reason and message
so that a policy with many configuration policies with frequent status
changes will still produce an event.

Additionally, event aggregation is essentially disabled by resetting the event counter
every second so that events that are common except for the message are not aggregated
to a single event.