### PR TITLE
Cache the API discovery information

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 # Ignore build and test binaries.
 bin/
 testbin/
+.go/

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.18.1
 	github.com/spf13/pflag v1.0.5
-	github.com/stolostron/go-template-utils/v2 v2.2.2
+	github.com/stolostron/go-template-utils/v2 v2.4.0
 	github.com/stolostron/governance-policy-propagator v0.0.0-20220217025800-1a04477f8f38
 	github.com/stretchr/testify v1.7.0
 	k8s.io/api v0.23.3

--- a/go.sum
+++ b/go.sum
@@ -1130,8 +1130,9 @@ github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
-github.com/stolostron/go-template-utils/v2 v2.2.2 h1:wGGfxzexV0xNHcT6XUlXLGj6K44pBDwRixD9wYEyhtc=
 github.com/stolostron/go-template-utils/v2 v2.2.2/go.mod h1:z4d9KZkkW5jAHns3bafVTmab+eq/jVsoFRYWbH37Qu4=
+github.com/stolostron/go-template-utils/v2 v2.4.0 h1:V391nVKzV4Ztsb33I44Kn6cdRPAKGBNAV4ntbd3fJ90=
+github.com/stolostron/go-template-utils/v2 v2.4.0/go.mod h1:Cmk7ZiCZwnUjAT86ajCoxTM9McxXeB5XcjgBwW+4Jw0=
 github.com/stolostron/governance-policy-propagator v0.0.0-20220217025800-1a04477f8f38 h1:a3mDbBUE0eVXdzv0IIsz6/48F7Ru6LxwPduryJU7UXQ=
 github.com/stolostron/governance-policy-propagator v0.0.0-20220217025800-1a04477f8f38/go.mod h1:8lcjUP24z9gIZ1nCydZyOxIqz6CpVDtVt5KPAlsi+tY=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=

--- a/test/e2e/case10_kind_field_test.go
+++ b/test/e2e/case10_kind_field_test.go
@@ -60,5 +60,14 @@ var _ = Describe("Test pod obj template handling", func() {
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
 		})
+		It("Cleans up", func() {
+			policies := []string{
+				case10ConfigPolicyNamePod,
+				case10ConfigPolicyNameCheck,
+				case10ConfigPolicyNameFail,
+			}
+
+			deleteConfigPolicies(policies)
+		})
 	})
 })

--- a/test/e2e/case11_apiserver_config_test.go
+++ b/test/e2e/case11_apiserver_config_test.go
@@ -122,5 +122,15 @@ var _ = Describe("Test APIServer Config policy", func() {
 				return utils.GetComplianceState(informPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 		})
+		It("Cleans up", func() {
+			policies := []string{
+				etcdEncryptionEnforceName,
+				etcdEncryptionInformName,
+				tlsProfileEnforceName,
+				tlsProfileInformName,
+			}
+
+			deleteConfigPolicies(policies)
+		})
 	})
 })

--- a/test/e2e/case12_list_compare_test.go
+++ b/test/e2e/case12_list_compare_test.go
@@ -101,6 +101,14 @@ var _ = Describe("Test list handling for musthave", func() {
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 		})
+		It("Cleans up", func() {
+			policies := []string{
+				case12ConfigPolicyNameInform,
+				case12ConfigPolicyNameEnforce,
+			}
+
+			deleteConfigPolicies(policies)
+		})
 	})
 	Describe("Create a policy with a list field on managed cluster in ns:"+testNamespace, func() {
 		It("should be created properly on the managed cluster", func() {
@@ -126,6 +134,14 @@ var _ = Describe("Test list handling for musthave", func() {
 
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
+		})
+		It("Cleans up", func() {
+			policies := []string{
+				case12ConfigPolicyNameRoleInform,
+				case12ConfigPolicyNameRoleEnforce,
+			}
+
+			deleteConfigPolicies(policies)
 		})
 	})
 	Describe("Create and patch a role on managed cluster in ns:"+testNamespace, func() {
@@ -161,6 +177,15 @@ var _ = Describe("Test list handling for musthave", func() {
 
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+		})
+		It("Cleans up", func() {
+			policies := []string{
+				case12RoleToPatch,
+				case12RolePatchEnforce,
+				case12RolePatchInform,
+			}
+
+			deleteConfigPolicies(policies)
 		})
 	})
 	Describe("Create and patch an oauth object on managed cluster in ns:"+testNamespace, func() {
@@ -269,6 +294,22 @@ var _ = Describe("Test list handling for musthave", func() {
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 		})
+
+		It("Cleans up", func() {
+			policies := []string{
+				case12OauthCreate,
+				case12OauthPatch,
+				case12OauthVerify,
+				case12SingleItemListCreate,
+				case12SingleItemListPatch,
+				case12SingleItemListInform,
+				case12SmallerListExistingCreate,
+				case12SmallerListExistingPatch,
+				case12SmallerListExistingInform,
+			}
+
+			deleteConfigPolicies(policies)
+		})
 	})
 	Describe("Create a deployment object with env vars on managed cluster in ns:"+testNamespace, func() {
 		It("should only add the list item with prefix and suffix whitespace once", func() {
@@ -305,6 +346,15 @@ var _ = Describe("Test list handling for musthave", func() {
 			envvars := containers[0].(map[string]interface{})["env"].([]interface{})
 			Expect(len(envvars)).To(Equal(1))
 		})
+
+		It("Cleans up", func() {
+			policies := []string{
+				case12WhitespaceListCreate,
+				case12WhitespaceListInform,
+			}
+
+			deleteConfigPolicies(policies)
+		})
 	})
 	Describe("Create a statefulset object with a byte quantity field on managed cluster in ns:"+testNamespace, func() {
 		It("should only add the list item with the rounded byte value once", func() {
@@ -338,6 +388,15 @@ var _ = Describe("Test list handling for musthave", func() {
 
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+		})
+
+		It("Cleans up", func() {
+			policies := []string{
+				case12ByteCreate,
+				case12ByteInform,
+			}
+
+			deleteConfigPolicies(policies)
 		})
 	})
 })

--- a/test/e2e/case13_templatization_test.go
+++ b/test/e2e/case13_templatization_test.go
@@ -146,6 +146,7 @@ var _ = Describe("Test templatization", func() {
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 			utils.Kubectl("delete", "configurationpolicy", case13CfgPolCreatePod, "-n", testNamespace)
 			utils.Kubectl("delete", "configurationpolicy", case13CfgPolVerifyPod, "-n", testNamespace)
+			utils.Kubectl("delete", "configurationpolicy", case13CfgPolVerifyPodWithConfigMap, "-n", testNamespace)
 		})
 	})
 	Describe("Use the generic lookup template to get the same resources from the previous tests", func() {
@@ -204,6 +205,9 @@ var _ = Describe("Test templatization", func() {
 
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
+		})
+		It("Cleans up", func() {
+			deleteConfigPolicies([]string{case13Unterminated, case13WrongArgs})
 		})
 	})
 	// Though the Bugzilla bug #2007575 references a different incorrect behavior, it's the same
@@ -277,8 +281,8 @@ var _ = Describe("Test templatization", func() {
 				1,
 			).Should(Equal("Hello world!\n"))
 		})
-		It("Should clean up", func() {
-			utils.Kubectl("delete", "configurationpolicy", case13UpdateRefObject, "-n", testNamespace)
+		It("Cleans up", func() {
+			deleteConfigPolicies([]string{case13UpdateRefObject})
 			utils.Kubectl("delete", "configmap", configMapName, "-n", "default")
 			utils.Kubectl("delete", "configmap", configMapReplName, "-n", "default")
 		})

--- a/test/e2e/case15_event_format_test.go
+++ b/test/e2e/case15_event_format_test.go
@@ -8,7 +8,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stolostron/config-policy-controller/test/utils"
 )
@@ -48,7 +49,7 @@ var _ = Describe("Testing compliance event formatting", func() {
 		ownerRefs[0].UID = parent.GetUID()
 		plcDef.SetOwnerReferences(ownerRefs)
 		_, err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).
-			Create(context.TODO(), plcDef, v1.CreateOptions{})
+			Create(context.TODO(), plcDef, metav1.CreateOptions{})
 		Expect(err).To(BeNil())
 
 		plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
@@ -93,7 +94,7 @@ var _ = Describe("Testing compliance event formatting", func() {
 		ownerRefs[0].UID = parent.GetUID()
 		plcDef.SetOwnerReferences(ownerRefs)
 		_, err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).
-			Create(context.TODO(), plcDef, v1.CreateOptions{})
+			Create(context.TODO(), plcDef, metav1.CreateOptions{})
 		Expect(err).To(BeNil())
 
 		plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
@@ -138,7 +139,7 @@ var _ = Describe("Testing compliance event formatting", func() {
 		ownerRefs[0].UID = parent.GetUID()
 		plcDef.SetOwnerReferences(ownerRefs)
 		_, err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).
-			Create(context.TODO(), plcDef, v1.CreateOptions{})
+			Create(context.TODO(), plcDef, metav1.CreateOptions{})
 		Expect(err).To(BeNil())
 
 		plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
@@ -183,7 +184,7 @@ var _ = Describe("Testing compliance event formatting", func() {
 		ownerRefs[0].UID = parent.GetUID()
 		plcDef.SetOwnerReferences(ownerRefs)
 		_, err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).
-			Create(context.TODO(), plcDef, v1.CreateOptions{})
+			Create(context.TODO(), plcDef, metav1.CreateOptions{})
 		Expect(err).To(BeNil())
 
 		plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
@@ -213,5 +214,30 @@ var _ = Describe("Testing compliance event formatting", func() {
 			case15BecomesNonCompliantParentName, "policy: "+testNamespace+"/"+case15BecomesNonCompliantName,
 			"^NonCompliant;", defaultTimeoutSeconds)
 		Expect(nonCompParentEvents).NotTo(BeEmpty())
+	})
+	It("Cleans up", func() {
+		policies := []string{
+			case15AlwaysCompliantParentName,
+			case15NeverCompliantParentName,
+			case15BecomesCompliantParentName,
+			case15BecomesNonCompliantParentName,
+		}
+		for _, policyName := range policies {
+			err := clientManagedDynamic.Resource(gvrPolicy).Namespace(testNamespace).Delete(
+				context.TODO(), policyName, metav1.DeleteOptions{},
+			)
+			if !k8serrors.IsNotFound(err) {
+				Expect(err).To(BeNil())
+			}
+		}
+
+		configPolicies := []string{
+			case15AlwaysCompliantName,
+			case15NeverCompliantName,
+			case15BecomesCompliantName,
+			case15BecomesNonCompliantName,
+		}
+
+		deleteConfigPolicies(configPolicies)
 	})
 })

--- a/test/e2e/case18_discovery_refresh_test.go
+++ b/test/e2e/case18_discovery_refresh_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2022 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	"context"
+	"os/exec"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stolostron/config-policy-controller/test/utils"
+)
+
+const (
+	case18PolicyName            = "policy-c18"
+	case18Policy                = "../resources/case18_discovery_refresh/policy.yaml"
+	case18PolicyTemplateName    = "policy-c18-template"
+	case18PolicyTemplatePreReqs = "../resources/case18_discovery_refresh/prereqs-for-template-policy.yaml"
+	case18PolicyTemplate        = "../resources/case18_discovery_refresh/policy-template.yaml"
+	case18ConfigMapName         = "c18-configmap"
+)
+
+var _ = Describe("Test discovery info refresh", func() {
+	It("Verifies that the discovery info is refreshed after a CRD is installed", func() {
+		By("Creating " + case18PolicyName + " on managed")
+		utils.Kubectl("apply", "-f", case18Policy, "-n", testNamespace)
+		policy := utils.GetWithTimeout(
+			clientManagedDynamic,
+			gvrConfigPolicy,
+			case18PolicyName,
+			testNamespace,
+			true,
+			defaultTimeoutSeconds,
+		)
+		Expect(policy).NotTo(BeNil())
+
+		By("Verifying " + case18PolicyName + " becomes compliant")
+		Eventually(func() interface{} {
+			policy := utils.GetWithTimeout(
+				clientManagedDynamic,
+				gvrConfigPolicy,
+				case18PolicyName,
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
+
+			return utils.GetComplianceState(policy)
+		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+	})
+
+	It("Verifies that the discovery info is refreshed when a template references a new object kind", func() {
+		By("Creating the prerequisites on managed")
+		// This needs to be wrapped in an eventually since the object can't be created immediately after the CRD
+		// is created.
+		Eventually(
+			func() interface{} {
+				cmd := exec.Command("kubectl", "apply", "-f", case18PolicyTemplatePreReqs)
+
+				err := cmd.Start()
+				if err != nil {
+					return err
+				}
+
+				err = cmd.Wait()
+
+				return err
+			},
+			defaultTimeoutSeconds,
+			1,
+		).Should(BeNil())
+
+		By("Creating " + case18PolicyTemplateName + " on managed")
+		utils.Kubectl("apply", "-f", case18PolicyTemplate, "-n", testNamespace)
+		policy := utils.GetWithTimeout(
+			clientManagedDynamic,
+			gvrConfigPolicy,
+			case18PolicyTemplateName,
+			testNamespace,
+			true,
+			defaultTimeoutSeconds,
+		)
+		Expect(policy).NotTo(BeNil())
+
+		By("Verifying " + case18PolicyTemplateName + " becomes compliant")
+		Eventually(func() interface{} {
+			policy := utils.GetWithTimeout(
+				clientManagedDynamic,
+				gvrConfigPolicy,
+				case18PolicyTemplateName,
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
+
+			return utils.GetComplianceState(policy)
+		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+	})
+
+	It("Cleans up", func() {
+		err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).Delete(
+			context.TODO(), case18PolicyName, metav1.DeleteOptions{},
+		)
+		if !k8serrors.IsNotFound(err) {
+			Expect(err).To(BeNil())
+		}
+
+		err = clientManagedDynamic.Resource(gvrCRD).Delete(
+			context.TODO(), "pizzaslices.food.example.com", metav1.DeleteOptions{},
+		)
+		if !k8serrors.IsNotFound(err) {
+			Expect(err).To(BeNil())
+		}
+
+		err = clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).Delete(
+			context.TODO(), case18PolicyTemplateName, metav1.DeleteOptions{},
+		)
+		if !k8serrors.IsNotFound(err) {
+			Expect(err).To(BeNil())
+		}
+
+		err = clientManagedDynamic.Resource(gvrCRD).Delete(
+			context.TODO(), "pizzaslices.diner.example.com", metav1.DeleteOptions{},
+		)
+		if !k8serrors.IsNotFound(err) {
+			Expect(err).To(BeNil())
+		}
+
+		err = clientManaged.CoreV1().ConfigMaps("default").Delete(
+			context.TODO(), case18ConfigMapName, metav1.DeleteOptions{},
+		)
+		if !k8serrors.IsNotFound(err) {
+			Expect(err).To(BeNil())
+		}
+	})
+})

--- a/test/e2e/case1_pod_handling_test.go
+++ b/test/e2e/case1_pod_handling_test.go
@@ -145,5 +145,20 @@ var _ = Describe("Test pod obj template handling", func() {
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 		})
+		It("Cleans up", func() {
+			policies := []string{
+				case1ConfigPolicyNameInform,
+				case1ConfigPolicyNameEnforce,
+				"policy-pod-check-emptycontainerlist",
+				"policy-pod-check-mh-list",
+				"policy-pod-check-mnh-incomplete",
+				"policy-pod-check-mnh",
+				"policy-pod-check-multiple-mh",
+				"policy-pod-check-moh",
+				"policy-pod-create-multiple",
+				"policy-pod-emptycontainerlist",
+			}
+			deleteConfigPolicies(policies)
+		})
 	})
 })

--- a/test/e2e/case2_role_handling_test.go
+++ b/test/e2e/case2_role_handling_test.go
@@ -90,5 +90,15 @@ var _ = Describe("Test role obj template handling", func() {
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 		})
+		It("Cleans up", func() {
+			policies := []string{
+				case2ConfigPolicyNameInform,
+				case2ConfigPolicyNameEnforce,
+				"policy-role-check-comp",
+				"policy-role-check-mnh",
+				"policy-role-check-moh",
+			}
+			deleteConfigPolicies(policies)
+		})
 	})
 })

--- a/test/e2e/case3_imgvuln_test.go
+++ b/test/e2e/case3_imgvuln_test.go
@@ -35,6 +35,8 @@ var _ = Describe("Test img vulnerability obj template handling", func() {
 
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
+
+			deleteConfigPolicies([]string{case3ConfigPolicyNameCSV})
 		})
 		It("should check for a subscription on managed cluster", func() {
 			By("Creating " + case3ConfigPolicyNameSub + " on managed")
@@ -48,6 +50,8 @@ var _ = Describe("Test img vulnerability obj template handling", func() {
 
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
+
+			deleteConfigPolicies([]string{case3ConfigPolicyNameSub})
 		})
 		It("should be noncompliant for no CRD found (kind)", func() {
 			By("Creating " + case3ConfigPolicyNameVuln + " on managed")
@@ -67,6 +71,8 @@ var _ = Describe("Test img vulnerability obj template handling", func() {
 
 				return utils.GetComplianceState(managedPlc)
 			}, 20, 1).Should(Equal("NonCompliant"))
+
+			deleteConfigPolicies([]string{case3ConfigPolicyNameVuln})
 		})
 		It("should be noncompliant for no CRD found (object)", func() {
 			By("Creating " + case3ConfigPolicyNameVulnObj + " on managed")
@@ -86,6 +92,8 @@ var _ = Describe("Test img vulnerability obj template handling", func() {
 
 				return utils.GetComplianceState(managedPlc)
 			}, 20, 1).Should(Equal("NonCompliant"))
+
+			deleteConfigPolicies([]string{case3ConfigPolicyNameVulnObj})
 		})
 	})
 })

--- a/test/e2e/case4_clusterversion_test.go
+++ b/test/e2e/case4_clusterversion_test.go
@@ -62,5 +62,14 @@ var _ = Describe("Test cluster version obj template handling", func() {
 			}, 120, 1).Should(Equal(
 				"clusterversions [version] found as specified, therefore this Object template is compliant"))
 		})
+		It("Cleans up", func() {
+			policies := []string{
+				case4ConfigPolicyName,
+				case4ConfigPolicyNameInform,
+				case4ConfigPolicyNamePatch,
+			}
+
+			deleteConfigPolicies(policies)
+		})
 	})
 })

--- a/test/e2e/case5_multi_test.go
+++ b/test/e2e/case5_multi_test.go
@@ -77,5 +77,14 @@ var _ = Describe("Test multiple obj template handling", func() {
 				case5PodName2, "default", true, defaultTimeoutSeconds)
 			Expect(pod2).NotTo(BeNil())
 		})
+		It("Cleans up", func() {
+			policies := []string{
+				case5ConfigPolicyNameInform,
+				case5ConfigPolicyNameEnforce,
+				case5ConfigPolicyNameCombo,
+			}
+
+			deleteConfigPolicies(policies)
+		})
 	})
 })

--- a/test/e2e/case6_no_ns_test.go
+++ b/test/e2e/case6_no_ns_test.go
@@ -65,5 +65,14 @@ var _ = Describe("Test multiple obj template handling", func() {
 				case6NSName2, true, defaultTimeoutSeconds)
 			Expect(ns2).NotTo(BeNil())
 		})
+		It("Cleans up", func() {
+			policies := []string{
+				case6ConfigPolicyNameNS,
+				case6ConfigPolicyNameRole,
+				case6ConfigPolicyNameCombo,
+			}
+
+			deleteConfigPolicies(policies)
+		})
 	})
 })

--- a/test/e2e/case7_no_spec_test.go
+++ b/test/e2e/case7_no_spec_test.go
@@ -179,5 +179,15 @@ var _ = Describe("Test cluster version obj template handling", func() {
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
 		})
+		It("Cleans up", func() {
+			policies := []string{
+				case7ConfigPolicyName,
+				case7ConfigPolicyNameNull,
+				case7ConfigPolicyNameInvalid,
+				case7ConfigPolicyNameInvalidInform,
+			}
+
+			deleteConfigPolicies(policies)
+		})
 	})
 })

--- a/test/e2e/case8_status_check_test.go
+++ b/test/e2e/case8_status_check_test.go
@@ -75,5 +75,15 @@ var _ = Describe("Test pod obj template handling", func() {
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
 		})
+		It("Cleans up", func() {
+			policies := []string{
+				case8ConfigPolicyNamePod,
+				case8ConfigPolicyNameCheck,
+				case8ConfigPolicyNameCheckFail,
+				case8ConfigPolicyNameEnforceFail,
+			}
+
+			deleteConfigPolicies(policies)
+		})
 	})
 })

--- a/test/e2e/case9_md_check_test.go
+++ b/test/e2e/case9_md_check_test.go
@@ -141,6 +141,20 @@ var _ = Describe("Test pod obj template handling", func() {
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 		})
+		It("Cleans up", func() {
+			policies := []string{
+				case9ConfigPolicyNamePod,
+				case9ConfigPolicyNameAnno,
+				case9ConfigPolicyNameNoAnno,
+				case9ConfigPolicyNameLabelPatch,
+				case9ConfigPolicyNameLabelCheck,
+				case9ConfigPolicyNameLabelAuto,
+				case9ConfigPolicyNameNSCreate,
+				case9ConfigPolicyNameIgnoreLabels,
+			}
+
+			deleteConfigPolicies(policies)
+		})
 	})
 	Describe("Create a namespace policy on managed cluster in ns:"+testNamespace, func() {
 		It("should create a namespace with multiple annotations on the managed cluster", func() {
@@ -188,6 +202,15 @@ var _ = Describe("Test pod obj template handling", func() {
 		It("should clean up the created namespace", func() {
 			By("Deleting the namespace from " + case9MultiAnnoNSCreate)
 			utils.Kubectl("delete", "ns", "case9-test-multi-annotation")
+		})
+		It("Cleans up", func() {
+			policies := []string{
+				case9MultiAnnoNSCreate,
+				case9CheckNSMusthave,
+				case9CheckNSMustonlyhave,
+			}
+
+			deleteConfigPolicies(policies)
 		})
 	})
 })

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -33,6 +33,7 @@ var (
 	clientManaged         kubernetes.Interface
 	clientManagedDynamic  dynamic.Interface
 	gvrConfigPolicy       schema.GroupVersionResource
+	gvrCRD                schema.GroupVersionResource
 	gvrPod                schema.GroupVersionResource
 	gvrRole               schema.GroupVersionResource
 	gvrNS                 schema.GroupVersionResource
@@ -67,6 +68,11 @@ var _ = BeforeSuite(func() {
 		Group:    "policy.open-cluster-management.io",
 		Version:  "v1",
 		Resource: "configurationpolicies",
+	}
+	gvrCRD = schema.GroupVersionResource{
+		Group:    "apiextensions.k8s.io",
+		Version:  "v1",
+		Resource: "customresourcedefinitions",
 	}
 	gvrPolicy = schema.GroupVersionResource{
 		Group:    "policy.open-cluster-management.io",

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -174,3 +174,14 @@ func LoadConfig(url, kubeconfig, context string) (*rest.Config, error) {
 
 	return nil, fmt.Errorf("could not create a valid kubeconfig")
 }
+
+func deleteConfigPolicies(policyNames []string) {
+	for _, policyName := range policyNames {
+		err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).Delete(
+			context.TODO(), policyName, metav1.DeleteOptions{},
+		)
+		if !errors.IsNotFound(err) {
+			Expect(err).To(BeNil())
+		}
+	}
+}

--- a/test/resources/case18_discovery_refresh/policy-template.yaml
+++ b/test/resources/case18_discovery_refresh/policy-template.yaml
@@ -1,0 +1,16 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-c18-template
+spec:
+  remediationAction: enforce
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: c18-configmap
+          namespace: default
+        data:
+          topping: '{{ index (lookup "diner.example.com/v1" "PizzaSlice" "default" "mypizza").spec.toppings 0 }}'

--- a/test/resources/case18_discovery_refresh/policy.yaml
+++ b/test/resources/case18_discovery_refresh/policy.yaml
@@ -1,0 +1,45 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-c18
+spec:
+  remediationAction: enforce
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: apiextensions.k8s.io/v1
+        kind: CustomResourceDefinition
+        metadata:
+          name: pizzaslices.food.example.com
+        spec:
+          group: food.example.com
+          versions:
+            - name: v1
+              served: true
+              storage: true
+              schema:
+                openAPIV3Schema:
+                  type: object
+                  properties:
+                    spec:
+                      type: object
+                      properties:
+                        toppings:
+                          type: array
+                          items:
+                            type: string
+          scope: Namespaced
+          names:
+            plural: pizzaslices
+            singular: pizzaslice
+            kind: PizzaSlice
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: food.example.com/v1
+        kind: PizzaSlice
+        metadata:
+          name: mypizza
+          namespace: default
+        spec:
+          toppings:
+            - meatballs

--- a/test/resources/case18_discovery_refresh/prereqs-for-template-policy.yaml
+++ b/test/resources/case18_discovery_refresh/prereqs-for-template-policy.yaml
@@ -1,0 +1,35 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: pizzaslices.diner.example.com
+spec:
+  group: diner.example.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                toppings:
+                  type: array
+                  items:
+                    type: string
+  scope: Namespaced
+  names:
+    plural: pizzaslices
+    singular: pizzaslice
+    kind: PizzaSlice
+---
+apiVersion: diner.example.com/v1
+kind: PizzaSlice
+metadata:
+  name: mypizza
+  namespace: default
+spec:
+  toppings:
+    - pulled pork


### PR DESCRIPTION
Prior to this PR, the API discovery information was refreshed on
every cycle (i.e. every 10 seconds) but this puts unnecessary load on
the Kubernetes API.

This PR makes it so that the API discovery information is refreshed
whenever an API resource (not an object) that is not in the discovery
information is encountered. It is also periodically updated every 10
minutes.

The first commit cleans up the created configuration policies after each test
since the tests that require API Discovery refreshes are slower after this change
and it was interfering with other tests.

Resolves:
https://github.com/stolostron/backlog/issues/20382