### PR TITLE
Synchronize logging levels with libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ GIT_HOST ?= github.com/stolostron
 
 PWD := $(shell pwd)
 BASE_DIR := $(shell basename $(PWD))
-export PATH=$(shell echo $$PATH):$(PWD)/bin
+export PATH := $(PWD)/bin:$(PATH)
 
 # Keep an existing GOPATH, make a private one if it is undefined
 GOPATH_DEFAULT := $(PWD)/.go

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	k8s.io/apimachinery v0.23.3
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.40.1
 	open-cluster-management.io/addon-framework v0.2.0
 	sigs.k8s.io/controller-runtime v0.11.1
 )
@@ -73,7 +74,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/apiextensions-apiserver v0.23.3 // indirect
 	k8s.io/component-base v0.23.3 // indirect
-	k8s.io/klog/v2 v2.40.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220124234850-424119656bbf // indirect
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	open-cluster-management.io/multicloud-operators-subscription v0.6.0 // indirect


### PR DESCRIPTION
Previously, libraries using `glog` could be configured through a flag
like `-v=3` (or `--v=3`), and this controller's zap logs could be
configured through a flag like `--zap-log-level=3`. However, libraries
using `klog` could not have their logging levels configured, and the
different logs might print differently if zap had JSON mode turned on.

This makes everything more consistent. The `v` flag is now passed on
to `klog`, which is more popular in our dependencies, and that same
flag will override the zap log level. Additionally, klog is sent
through the zap logr, so the formats will be the same.

Refs:
 - https://github.com/stolostron/backlog/issues/19030

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>