### PR TITLE
Refresh the discovery info only once per object template

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -1168,21 +1168,7 @@ func (r *ConfigurationPolicyReconciler) getMapping(
 
 	// initializes a mapping between Kind and APIVersion to a resource name
 	mapper := restmapper.NewDiscoveryRESTMapper(r.apiGroups)
-
 	mapping, err = mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-	if err != nil {
-		log.V(2).Info(
-			"The REST mapping for the GVK failed. Refreshing the discovery info and trying again.",
-			"GVK", gvk.String(),
-		)
-
-		discoveryErr := r.refreshDiscoveryInfo()
-		if discoveryErr == nil {
-			mapper = restmapper.NewDiscoveryRESTMapper(r.apiGroups)
-			mapping, err = mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-		}
-	}
-
 	mappingErrMsg := ""
 
 	if err != nil {


### PR DESCRIPTION
This handles the case where `isObjectNamespaced` refreshes the discovery
info but cannot find the API resource, so it is marked as non
namespaced. Then `getMapping` refreshes the discovery info and finds the
API resource, but it was previously marked as not namespaced.

Additionally, this speeds things up when processing policies related to
objects where the API resource is not installed.