### PR TITLE
[WIP] Use log-utils to configure logging

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -1377,7 +1377,7 @@ func enforceByCreatingOrDeleting(obj singleObject, dclient dynamic.Interface) (r
 	} else {
 		log.Info("Enforcing the policy by deleting the object")
 
-		if completed, err = deleteObject(res, obj.name, obj.namespace); completed {
+		if completed, err = deleteObject(res, obj.name, obj.namespace); !completed {
 			reason = "K8s deletion error"
 			msg = fmt.Sprintf("%v %v exists, and cannot be deleted, reason: `%v`", obj.gvr.Resource, idStr, err)
 		} else {

--- a/deploy/manager/manager.yaml
+++ b/deploy/manager/manager.yaml
@@ -22,6 +22,8 @@ spec:
           args:
             - "--enable-lease=true"
             - "--hubconfig-secret-name=hub-kubeconfig"
+            - "--log-level=2"
+            - "--v=0"
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -47,6 +47,8 @@ spec:
       - args:
         - --enable-lease=true
         - --hubconfig-secret-name=hub-kubeconfig
+        - --log-level=2
+        - --v=0
         command:
         - config-policy-controller
         env:

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,12 @@ go 1.17
 
 require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
+	github.com/go-logr/zapr v1.2.3
 	github.com/google/go-cmp v0.5.7
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.18.1
 	github.com/spf13/pflag v1.0.5
+	github.com/stolostron/go-log-utils v0.1.0
 	github.com/stolostron/go-template-utils/v2 v2.4.0
 	github.com/stolostron/governance-policy-propagator v0.0.0-20220217025800-1a04477f8f38
 	github.com/stretchr/testify v1.7.0
@@ -34,7 +36,6 @@ require (
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-logr/logr v1.2.2 // indirect
-	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
 	github.com/golang/glog v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1130,6 +1130,8 @@ github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
+github.com/stolostron/go-log-utils v0.1.0 h1:YRi84JogWKHCfrif46m/4rep+ucsc80c9667FzaBbTA=
+github.com/stolostron/go-log-utils v0.1.0/go.mod h1:2Uc5mbuLvSFpoXFFEKRTEFOlR7nqGVMu9mbU+FIttTI=
 github.com/stolostron/go-template-utils/v2 v2.2.2/go.mod h1:z4d9KZkkW5jAHns3bafVTmab+eq/jVsoFRYWbH37Qu4=
 github.com/stolostron/go-template-utils/v2 v2.4.0 h1:V391nVKzV4Ztsb33I44Kn6cdRPAKGBNAV4ntbd3fJ90=
 github.com/stolostron/go-template-utils/v2 v2.4.0/go.mod h1:Cmk7ZiCZwnUjAT86ajCoxTM9McxXeB5XcjgBwW+4Jw0=

--- a/main.go
+++ b/main.go
@@ -12,7 +12,9 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/go-logr/zapr"
 	"github.com/spf13/pflag"
+	"github.com/stolostron/go-log-utils/zaputil"
 	corev1 "k8s.io/api/core/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -29,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	policyv1 "github.com/stolostron/config-policy-controller/api/v1"
@@ -58,8 +59,12 @@ func init() {
 }
 
 func main() {
-	opts := zap.Options{}
-	opts.BindFlags(flag.CommandLine)
+	zflags := zaputil.FlagConfig{
+		LevelName:   "log-level",
+		EncoderName: "log-encoder",
+	}
+
+	zflags.Bind(flag.CommandLine)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 
 	var clusterName, hubConfigSecretNs, hubConfigSecretName, probeAddr string
@@ -90,36 +95,27 @@ func main() {
 
 	pflag.Parse()
 
-	// If the v flag is set, then configure the zap level to match
-	vFlag := flag.Lookup("v")
-	if vFlag != nil {
-		err := flag.Set("zap-log-level", vFlag.Value.String())
-		if err != nil {
-			log.Error(err, "Unable to set zap-log-level", "desiredValue", vFlag.Value.String())
-		}
+	ctrlZap, err := zflags.BuildForCtrl()
+	if err != nil {
+		panic(fmt.Sprintf("Failed to build zap logger for controller: %v", err))
 	}
 
-	logr := zap.New(zap.UseFlagOptions(&opts))
-	ctrl.SetLogger(logr)
+	ctrl.SetLogger(zapr.NewLogger(ctrlZap))
 
 	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(klogFlags)
 
-	// Sync the glog and klog flags (without this, setting -v=x will not adjust the klog level used by dependencies)
-	flag.CommandLine.VisitAll(func(f1 *flag.Flag) {
-		f2 := klogFlags.Lookup(f1.Name)
-		if f2 != nil {
-			value := f1.Value.String()
-			if err := f2.Value.Set(value); err != nil {
-				if f1.Name != "log_backtrace_at" { // skip this one flag - klog doesn't like glog's default
-					log.Error(err, "Unable to sync klog flag", "name", f1.Name, "desiredValue", f1.Value.String())
-				}
-			}
-		}
-	})
+	err = zaputil.SyncWithGlogFlags(klogFlags)
+	if err != nil {
+		log.Error(err, "Failed to synchronize klog and glog flags, continuing with what succeeded")
+	}
 
-	// send klog messages through our zap logger so they look the same (console vs JSON)
-	klog.SetLogger(logr)
+	klogZap, err := zaputil.BuildForKlog(zflags.GetConfig(), klogFlags)
+	if err != nil {
+		log.Error(err, "Failed to build zap logger for klog, those logs will not go through zap")
+	} else {
+		klog.SetLogger(zapr.NewLogger(klogZap).WithName("klog"))
+	}
 
 	printVersion()
 


### PR DESCRIPTION
The shared package will allow us to more easily configure this on more
of our controllers.

For reference on previous work, see
github.com/stolostron/config-policy-controller/pull/242

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>

This is a work-in-progress using my fork until the package is actually implemented in https://github.com/stolostron/go-log-utils