### PR TITLE
Fix default hub kubeconfig name

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func main() {
 	pflag.StringVar(&clusterName, "cluster-name", "acm-managed-cluster", "Name of the cluster")
 	pflag.StringVar(&hubConfigSecretNs, "hubconfig-secret-ns", "open-cluster-management-agent-addon",
 		"Namespace for hub config kube-secret")
-	pflag.StringVar(&hubConfigSecretName, "hubconfig-secret-name", "policy-controller-hub-kubeconfig",
+	pflag.StringVar(&hubConfigSecretName, "hubconfig-secret-name", "config-policy-controller-hub-kubeconfig",
 		"Name of the hub config kube-secret")
 	pflag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	pflag.BoolVar(&enableLeaderElection, "leader-elect", true,


### PR DESCRIPTION
This hub kubeconfig is used when the `lease` API is not available on the
managed cluster, for example if it is an OCP 3.11 cluster. The name of
the secret with that kubeconfig was not updated when the addon name
changed.

Fixes https://github.com/stolostron/backlog/issues/21200

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>