### PR TITLE
Could it be true that a boolean is getting passed by reference here

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -1873,7 +1873,7 @@ func handleKeys(
 		mapMtx.Unlock()
 
 		if keyUpdateNeeded {
-			updateNeeded = keyUpdateNeeded
+			updateNeeded = true
 
 			if strings.EqualFold(string(remediation), string(policyv1.Inform)) || isStatus {
 				return true, "", false


### PR DESCRIPTION
See logs and more information in the referenced issue.  The log shows
the `Queuing an update` message but we never get the `Updating the
object` log entry with all logging enabled.

Refs:
 - https://github.com/stolostron/backlog/issues/21908

Signed-off-by: Gus Parvin <gparvin@redhat.com>