### PR TITLE
Status in a policy shouldn't prevent spec updates

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -1836,6 +1836,7 @@ func handleKeys(
 	)
 	var err error
 	var updateNeeded bool
+	var statusUpdated bool
 
 	for key := range unstruct.Object {
 		isStatus := key == "status"
@@ -1873,13 +1874,15 @@ func handleKeys(
 		mapMtx.Unlock()
 
 		if keyUpdateNeeded {
-			updateNeeded = true
-
-			if strings.EqualFold(string(remediation), string(policyv1.Inform)) || isStatus {
+			if strings.EqualFold(string(remediation), string(policyv1.Inform)) {
 				return true, "", false
+			} else if isStatus {
+				statusUpdated = true
+				log.Info("Ignoring an update to the object status", "key", key)
+			} else {
+				updateNeeded = true
+				log.Info("Queuing an update for the object due to a value mismatch", "key", key)
 			}
-
-			log.Info("Queuing an update for the object due to a value mismatch", "key", key)
 		}
 	}
 
@@ -1902,7 +1905,7 @@ func handleKeys(
 		log.Info("Updated the object based on the template definition")
 	}
 
-	return false, "", false
+	return statusUpdated, "", false
 }
 
 // checkAndUpdateResource checks each individual key of a resource and passes it to handleKeys to see if it

--- a/test/resources/case8_status_check/case8_pod_change.yaml
+++ b/test/resources/case8_status_check/case8_pod_change.yaml
@@ -1,0 +1,25 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-pod-invalid
+spec:
+  remediationAction: enforce
+  namespaceSelector:
+    exclude: ["kube-*"]
+    include: ["default"]
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: nginx-badpod-e2e-8
+        spec:
+          containers:
+            - name: nginx
+              image: nginx:0.0.800
+              ports:
+                - containerPort: 80
+          activeDeadlineSeconds: 10
+        status:
+          phase: Failed

--- a/test/resources/case8_status_check/case8_pod_fail.yaml
+++ b/test/resources/case8_status_check/case8_pod_fail.yaml
@@ -1,0 +1,24 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-pod-invalid
+spec:
+  remediationAction: enforce
+  namespaceSelector:
+    exclude: ["kube-*"]
+    include: ["default"]
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: nginx-badpod-e2e-8
+        spec:
+          containers:
+            - name: nginx
+              image: nginx:0.0.800
+              ports:
+                - containerPort: 80
+        status:
+          phase: Running


### PR DESCRIPTION
The upgrade policy had a value in the status and spec sections of a
ClusterVersion resource.  The config policy controller ignored the
update because there was a status update.  Change is to still ignore
the status update, but don't ignore the spec update.

Refs:
 - https://github.com/stolostron/backlog/issues/21908

Signed-off-by: Gus Parvin <gparvin@redhat.com>