### PR TITLE
Handle objects that have omitted empty values

### DIFF
--- a/pkg/controller/configurationpolicy/configurationpolicy_utils.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_utils.go
@@ -104,6 +104,10 @@ func checkFieldsWithSort(mergedObj map[string]interface{}, oldObj map[string]int
 			//if field is a map, recurse to check for a match
 			oVal, ok := oldObj[i].(map[string]interface{})
 			if !ok {
+				if len(mVal) == 0 {
+					break
+				}
+
 				match = false
 				break
 			} else if !checkFieldsWithSort(mVal, oVal) {
@@ -122,6 +126,10 @@ func checkFieldsWithSort(mergedObj map[string]interface{}, oldObj map[string]int
 			//if field is a generic list, sort and iterate through them to make sure each value matches
 			oVal, ok := oldObj[i].([]interface{})
 			if !ok {
+				if len(mVal) == 0 {
+					break
+				}
+
 				match = false
 				break
 			}

--- a/pkg/controller/configurationpolicy/configurationpolicy_utils_test.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_utils_test.go
@@ -50,3 +50,20 @@ func TestFormatTemplateStringAnnotation(t *testing.T) {
 	policyTemplateFormatted := formatMetadata(policyTemplate)
 	assert.Equal(t, policyTemplateFormatted["annotations"], "not-an-annotation")
 }
+
+func TestCheckFieldsWithSort(t *testing.T) {
+	t.Parallel()
+
+	oldObj := map[string]interface{}{
+		"nonResourceURLs": []string{"/version", "/healthz"},
+		"verbs":           []string{"get"},
+	}
+	mergedObj := map[string]interface{}{
+		"nonResourceURLs": []string{"/version", "/healthz"},
+		"verbs":           []string{"get"},
+		"apiGroups":       []interface{}{},
+		"resources":       []interface{}{},
+	}
+
+	assert.True(t, checkFieldsWithSort(mergedObj, oldObj))
+}


### PR DESCRIPTION
If a policy specifies an empty array or map in its object definition
and the property is set to `omitEmpty`, then the controller will
mark the policy as noncompliant when it compares the policy with the
object retrieved from the API since the property wouldn't be returned.

This commit makes it so that an omitted array or map value is equal to
it being empty.

This is a backport of https://github.com/stolostron/config-policy-controller/commit/0de039697af0d406b48b6bd9fa4c48a196d8507e.

Resolves:
https://bugzilla.redhat.com/show_bug.cgi?id=2088486