### PR TITLE
Use a volume mounted secret for the hub kubeconfig

### DIFF
--- a/deploy/manager/manager.yaml
+++ b/deploy/manager/manager.yaml
@@ -21,7 +21,6 @@ spec:
           - config-policy-controller
           args:
             - "--enable-lease=true"
-            - "--hubconfig-secret-name=hub-kubeconfig"
             - "--log-level=2"
             - "--v=0"
           imagePullPolicy: Always

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -46,7 +46,6 @@ spec:
       containers:
       - args:
         - --enable-lease=true
-        - --hubconfig-secret-name=hub-kubeconfig
         - --log-level=2
         - --v=0
         command:


### PR DESCRIPTION
Previously, the hub kubeconfig was read from a secret. This meant that
if the config expired and the secret was updated, the controller here
would not get the updated cert. Now, we use a volume mount with the
config, which gets automagically updated.

Refs:
 - https://github.com/stolostron/backlog/issues/22651

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>