### PR TITLE
Add Action to run Policy Framework tests on PRs

### DIFF
--- a/.github/workflows/framework-kind.yml
+++ b/.github/workflows/framework-kind.yml
@@ -1,0 +1,91 @@
+name: Policy Framework KinD tests
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release-2.[5-9]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  kind-tests:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: localhost:5000
+    strategy:
+      matrix:
+        # Run tests on oldest and newest supported OCP Kubernetes
+        # - OCP 4.5 runs Kubernetes v1.18
+        # KinD tags: https://hub.docker.com/r/kindest/node/tags
+        kind:
+          - 'v1.18.15'
+          - 'latest'
+        deployOnHub:
+          - 'true'
+          - 'false'
+
+    name: Policy Framework KinD tests
+    steps:
+    - name: Checkout Config Policy Controller
+      uses: actions/checkout@v2
+      with:
+        path: config-policy-controller
+        fetch-depth: 0 # Fetch all history for all tags and branches
+
+    - name: Checkout Policy Framework
+      uses: actions/checkout@v2
+      with:
+        path: governance-policy-framework
+        repository: stolostron/governance-policy-framework
+        ref: ${{ github.event.pull_request.base.ref }}
+
+    - name: Set up Go 1.17
+      uses: actions/setup-go@v2
+      id: go
+      with:
+        go-version: '1.17'
+
+    - name: Policy Framework cluster bootstrap
+      working-directory: governance-policy-framework
+      env:
+        deployOnHub: ${{ matrix.deployOnHub }}
+      run: |
+        make e2e-dependencies
+        make kind-bootstrap-cluster
+
+        echo "* Listing all pods on cluster..."
+        kubectl get pods -A
+
+        # save kubeconfig paths for use in other steps
+        echo "MANAGED_KUBECONFIG=$(pwd)/kubeconfig_managed" >> $GITHUB_ENV
+        echo "HUB_KUBECONFIG=$(pwd)/kubeconfig_hub" >> $GITHUB_ENV
+
+    - name: Patch image
+      working-directory: config-policy-controller
+      env:
+        deployOnHub: ${{ matrix.deployOnHub }}
+        WATCH_NAMESPACE: managed
+      run: |
+        export KUBECONFIG=${MANAGED_KUBECONFIG}
+        if [[ "${deployOnHub}" == "true" ]]; then
+          export KIND_NAME=hub
+        else
+          export KIND_NAME=managed
+        fi
+
+        make build-images
+        make kind-deploy-controller-dev
+
+    - name: Policy Framework e2e tests
+      working-directory: governance-policy-framework
+      run: |
+        make e2e-test
+
+    - name: Debug
+      if: ${{ failure() }}
+      working-directory: governance-policy-framework
+      run: |
+        make e2e-debug


### PR DESCRIPTION
This will just run the e2e/kind tests from the policy framework repo -
performing some basic validation that all the policy components will
still work well together with any changes here.

Refs:
 - https://github.com/stolostron/backlog/issues/21795

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>