### PR TITLE
[release-2.6] Fix the conditions history in compliancyDetails

### DIFF
--- a/controllers/configurationpolicy_controller_test.go
+++ b/controllers/configurationpolicy_controller_test.go
@@ -675,3 +675,69 @@ func TestShouldEvaluatePolicy(t *testing.T) {
 		)
 	}
 }
+
+func TestAppendCondition(t *testing.T) {
+	conditions := []policyv1.Condition{}
+	newCond1 := &policyv1.Condition{
+		Type:               "violation",
+		LastTransitionTime: metav1.Time{Time: metav1.Now().Add(5 * time.Minute)},
+		Reason:             "K8s `must have` object already exists",
+		Message:            "some message",
+	}
+
+	conditions = AppendCondition(conditions, newCond1)
+	if len(conditions) != 1 {
+		t.Fatalf("Expected a single condition to be appended but the length was %d", len(conditions))
+	}
+
+	lastTransition := metav1.Time{Time: metav1.Now().Add(5 * time.Minute)}
+	newCond2 := &policyv1.Condition{
+		Type:               "violation",
+		LastTransitionTime: lastTransition,
+		Reason:             "K8s `must have` object already exists",
+		Message:            "some message",
+	}
+	conditions = AppendCondition(conditions, newCond2)
+
+	if len(conditions) != 1 {
+		t.Fatalf("Expected the single condition to be updated and not appended but the length was %d", len(conditions))
+	}
+
+	if conditions[0].LastTransitionTime != lastTransition {
+		t.Fatal("The single condition was not updated with the last transition time")
+	}
+
+	newCond3 := &policyv1.Condition{
+		Type:               "violation",
+		LastTransitionTime: lastTransition,
+		Reason:             "K8s creation success",
+		Message:            "some other message",
+	}
+	conditions = AppendCondition(conditions, newCond3)
+
+	if len(conditions) != 2 {
+		t.Fatalf("Expected the new condition to be appended but the length was %d", len(conditions))
+	}
+
+	if conditions[0].Reason != newCond2.Reason || conditions[1].Reason != newCond3.Reason {
+		t.Fatalf("Expected the new condition to be appended the order is incorrect")
+	}
+
+	for i := 0; i < complianceStatusConditionLimit+2; i++ {
+		newCond := &policyv1.Condition{
+			Type:               "violation",
+			LastTransitionTime: lastTransition,
+			Reason:             "K8s creation success",
+			Message:            fmt.Sprintf("some other message%d", i),
+		}
+		conditions = AppendCondition(conditions, newCond)
+	}
+
+	if len(conditions) != complianceStatusConditionLimit {
+		t.Fatalf(
+			"Expected the conditions array to be limited to %d but the length was %d",
+			complianceStatusConditionLimit,
+			len(conditions),
+		)
+	}
+}

--- a/test/e2e/case1_pod_handling_test.go
+++ b/test/e2e/case1_pod_handling_test.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"open-cluster-management.io/config-policy-controller/test/utils"
 )
@@ -47,12 +48,32 @@ var _ = Describe("Test pod obj template handling", func() {
 			plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
 				case1ConfigPolicyNameEnforce, testNamespace, true, defaultTimeoutSeconds)
 			Expect(plc).NotTo(BeNil())
+
 			Eventually(func() interface{} {
 				managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
 					case1ConfigPolicyNameEnforce, testNamespace, true, defaultTimeoutSeconds)
 
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+
+			By("verifying status.compliancyDetails[].conditions")
+			Eventually(func(g Gomega) {
+				managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+					case1ConfigPolicyNameEnforce, testNamespace, true, defaultTimeoutSeconds)
+
+				compliancyDetails, _, _ := unstructured.NestedSlice(managedPlc.Object, "status", "compliancyDetails")
+				g.Expect(compliancyDetails).To(HaveLen(1))
+
+				conditions, ok := compliancyDetails[0].(map[string]interface{})["conditions"].([]interface{})
+				g.Expect(ok).To(BeTrue())
+				g.Expect(conditions).To(HaveLen(2))
+				g.Expect(conditions[0].(map[string]interface{})["reason"]).To(Equal("K8s creation success"))
+				g.Expect(conditions[1].(map[string]interface{})["reason"]).To(
+					Equal("K8s `must have` object already exists"),
+				)
+			}, defaultTimeoutSeconds, 1).Should(Succeed())
+
+			By("verifying that " + case1ConfigPolicyNameInform + " is compliant")
 			Eventually(func() interface{} {
 				informPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
 					case1ConfigPolicyNameInform, testNamespace, true, defaultTimeoutSeconds)

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -206,8 +206,9 @@ func GetComplianceState(managedPlc *unstructured.Unstructured) (result interface
 func GetStatusMessage(managedPlc *unstructured.Unstructured) (result interface{}) {
 	if managedPlc.Object["status"] != nil {
 		detail := managedPlc.Object["status"].(map[string]interface{})["compliancyDetails"].([]interface{})[0]
+		conditions := detail.(map[string]interface{})["conditions"].([]interface{})
 
-		return detail.(map[string]interface{})["conditions"].([]interface{})[0].(map[string]interface{})["message"]
+		return conditions[len(conditions)-1].(map[string]interface{})["message"]
 	}
 
 	return nil


### PR DESCRIPTION
This is a backport of #392 but needed to do it manually due to a test case being slightly different in 2.6.

The status.compliancyDetails[].conditions array was always limited to just a single condition due to a bug. This sets the limit to 10 instead.

Relates:
https://issues.redhat.com/browse/ACM-2708