### PR TITLE
Add a symlink to the Dockerfile at root to allow us to enable RHTAP builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+build/Dockerfile


### PR DESCRIPTION
## Summary

RHTAP (Red Hat Trusted Application Pipeline) is a new CI/CD tool that we would like to use to build this repo, but it requires (for now) that the Dockerfile exist at the root of the repo!  The RHTAP team suggested we solve this repository's folder-nested Dockerfile with a symbolic link!