### PR TITLE
Bug: message for `enforce` omits objects when multiple namespaces are specified

### DIFF
--- a/controllers/configurationpolicy_controller_test.go
+++ b/controllers/configurationpolicy_controller_test.go
@@ -434,7 +434,7 @@ func TestSortRelatedObjectsAndUpdate(t *testing.T) {
 	assert.True(t, relatedList[0].Object.Metadata.Name == "bar")
 }
 
-func TestCreateInformStatus(t *testing.T) {
+func TestCreateMergedStatus(t *testing.T) {
 	policy := &policyv1.ConfigurationPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
@@ -472,7 +472,7 @@ func TestCreateInformStatus(t *testing.T) {
 	}
 
 	// Test 1 NonCompliant resource
-	createInformStatus(!mustNotHave, numCompliant, numNonCompliant,
+	createMergedStatus(!mustNotHave, numCompliant, numNonCompliant,
 		compliantObjects, nonCompliantObjects, policy, objData)
 	assert.True(t, policy.Status.CompliancyDetails[0].ComplianceState == policyv1.NonCompliant)
 
@@ -483,7 +483,7 @@ func TestCreateInformStatus(t *testing.T) {
 	numNonCompliant = 2
 
 	// Test 2 NonCompliant resources
-	createInformStatus(!mustNotHave, numCompliant, numNonCompliant,
+	createMergedStatus(!mustNotHave, numCompliant, numNonCompliant,
 		compliantObjects, nonCompliantObjects, policy, objData)
 	assert.True(t, policy.Status.CompliancyDetails[0].ComplianceState == policyv1.NonCompliant)
 
@@ -492,7 +492,7 @@ func TestCreateInformStatus(t *testing.T) {
 
 	// Test 0 resources
 	numNonCompliant = 0
-	createInformStatus(!mustNotHave, numCompliant, numNonCompliant,
+	createMergedStatus(!mustNotHave, numCompliant, numNonCompliant,
 		compliantObjects, nonCompliantObjects, policy, objData)
 	assert.True(t, policy.Status.CompliancyDetails[0].ComplianceState == policyv1.NonCompliant)
 
@@ -508,7 +508,7 @@ func TestCreateInformStatus(t *testing.T) {
 	numNonCompliant = 1
 
 	// Test 1 compliant and 1 noncompliant resource  NOTE: This use case is the new behavior change!
-	createInformStatus(!mustNotHave, numCompliant, numNonCompliant,
+	createMergedStatus(!mustNotHave, numCompliant, numNonCompliant,
 		compliantObjects, nonCompliantObjects, policy, objData)
 	assert.True(t, policy.Status.CompliancyDetails[0].ComplianceState == policyv1.NonCompliant)
 
@@ -522,7 +522,7 @@ func TestCreateInformStatus(t *testing.T) {
 	delete(nonCompliantObjects, "test2")
 
 	// Test 2 compliant resources
-	createInformStatus(!mustNotHave, numCompliant, numNonCompliant,
+	createMergedStatus(!mustNotHave, numCompliant, numNonCompliant,
 		compliantObjects, nonCompliantObjects, policy, objData)
 	assert.True(t, policy.Status.CompliancyDetails[0].ComplianceState == policyv1.Compliant)
 }

--- a/test/e2e/case8_status_check_test.go
+++ b/test/e2e/case8_status_check_test.go
@@ -25,7 +25,7 @@ const (
 )
 
 var _ = Describe("Test pod obj template handling", func() {
-	Describe("Create a policy on managed cluster in ns:"+testNamespace, func() {
+	Describe("Create a policy on managed cluster in ns:"+testNamespace, Ordered, func() {
 		It("should create a policy properly on the managed cluster", func() {
 			By("Creating " + case8ConfigPolicyNamePod + " on managed")
 			utils.Kubectl("apply", "-f", case8PolicyYamlPod, "-n", testNamespace)
@@ -89,7 +89,7 @@ var _ = Describe("Test pod obj template handling", func() {
 			deleteConfigPolicies(policies)
 		})
 	})
-	Describe("Create a policy with status on managed cluster in ns:"+testNamespace, func() {
+	Describe("Create a policy with status on managed cluster in ns:"+testNamespace, Ordered, func() {
 		It("should create a policy properly on the managed cluster", func() {
 			By("Creating " + case8ConfigPolicyStatusPod + " on managed")
 			utils.Kubectl("apply", "-f", case8PolicyYamlBadPod, "-n", testNamespace)
@@ -140,12 +140,14 @@ var _ = Describe("Test pod obj template handling", func() {
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 		})
-		It("Cleans up", func() {
+		AfterEach(func() {
 			policies := []string{
 				case8ConfigPolicyStatusPod,
 			}
 
 			deleteConfigPolicies(policies)
+
+			utils.Kubectl("delete", "pod", "nginx-badpod-e2e-8", "-n", "default", "--ignore-not-found")
 		})
 	})
 })

--- a/test/resources/case5_multi/case5_multi_namespace_enforce.yaml
+++ b/test/resources/case5_multi/case5_multi_namespace_enforce.yaml
@@ -1,0 +1,24 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-multi-namespace-enforce
+  namespace: managed
+spec:
+  remediationAction: enforce
+  pruneObjectBehavior: DeleteAll
+  namespaceSelector:
+    exclude: ["kube-*"]
+    include: ["n1","n2","n3"]
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: case5-multi-namespace-enforce-pod
+        spec:
+          containers:
+            - image: nginx:1.7.9
+              name: nginx
+              ports:
+                - containerPort: 80

--- a/test/resources/case5_multi/case5_multi_namespace_inform.yaml
+++ b/test/resources/case5_multi/case5_multi_namespace_inform.yaml
@@ -1,0 +1,24 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-multi-namespace-inform
+  namespace: managed
+spec:
+  remediationAction: inform
+  pruneObjectBehavior: DeleteAll
+  namespaceSelector:
+    exclude: ["kube-*"]
+    include: ["n1","n2","n3"]
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: case5-multi-namespace-inform-pod
+        spec:
+          containers:
+            - image: nginx:1.7.9
+              name: nginx
+              ports:
+                - containerPort: 80

--- a/test/resources/case5_multi/case5_multi_obj_template_enforce.yaml
+++ b/test/resources/case5_multi/case5_multi_obj_template_enforce.yaml
@@ -1,0 +1,49 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-pod-multi-obj-temp-enforce
+  namespace: managed
+spec:
+  remediationAction: enforce
+  pruneObjectBehavior: DeleteAll
+  namespaceSelector:
+    exclude: ["kube-*"]
+    include: ["n1","n2","n3"]
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: case5-multi-obj-temp-pod-11
+        spec:
+          containers:
+            - image: nginx:1.7.9
+              name: nginx
+              ports:
+                - containerPort: 80
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: case5-multi-obj-temp-pod-22
+        spec:
+          containers:
+            - image: nginx:1.7.9
+              name: nginx
+              ports:
+                - containerPort: 80
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: case5-multi-obj-temp-pod-33
+        spec:
+          containers:
+            - image: nginx:1.7.9
+              name: nginx
+              ports:
+                - containerPort: 80
+


### PR DESCRIPTION
`ConfigurationPolicy` message for `enforce` omits objects when multiple namespaces are specified

When set to `inform`, the full list of objects is shown. But when set to `enforce` (the first two messages displayed), only the last object message is shown. In multiple namespaces, the message should be merged.

Should be fixed like this example: 
**pod [pod1] in namespace test1 found; [pod1] in namespace test2 found as specified, therefore this Object template is compliant**

Ref: https://issues.redhat.com/browse/ACM-2604