### PR TITLE
[release-2.7] Bug:  crash-looping config-policy-controller-uninstaller

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -196,7 +196,14 @@ func (r *ConfigurationPolicyReconciler) PeriodicallyExecConfigPolicies(
 			_ = r.refreshDiscoveryInfo()
 		}
 
-		if discoveryErr == nil {
+		cleanupImmediately, err := r.cleanupImmediately()
+		if err != nil {
+			log.Error(err, "Failed to determine if it's time to cleanup immediately")
+
+			skipLoop = true
+		}
+
+		if !skipLoop && (discoveryErr == nil || cleanupImmediately) {
 			// This retrieves the policies from the controller-runtime cache populated by the watch.
 			err := r.List(context.TODO(), &policiesList)
 			if err != nil {
@@ -205,13 +212,6 @@ func (r *ConfigurationPolicyReconciler) PeriodicallyExecConfigPolicies(
 				skipLoop = true
 			}
 		} else {
-			skipLoop = true
-		}
-
-		cleanupImmediately, err := r.cleanupImmediately()
-		if err != nil {
-			log.Error(err, "Failed to determine if it's time to cleanup immediately")
-
 			skipLoop = true
 		}
 


### PR DESCRIPTION
Description of problem:

Some HyperShift hosted clusters have been getting stuck in the uninstalling state (without transitioning to the error state), indicating a problem with ACM's deletion of the ManagedCluster object. For these clusters, we've noticed that the ManagedCluster object on the service/hub cluster has a DeletionTimestamp in the past and a status condition of ManagedClusterLeaseUpdateStopped. On the corresponding management cluster, we've noticed that the klusterlet-$CID namespace contains a pod named config-policy-controller-uninstall that's crash-looping with the following error.

Signed-off-by: Yi Rae Kim <yikim@redhat.com>
(cherry picked from commit 7c79594924c40adf6f63091038addf7a125bf65e)

Ref: https://issues.redhat.com/browse/ACM-4854