### PR TITLE
[release-2.7] Manual cherry-pick of status retries

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -518,13 +518,21 @@ func (r *ConfigurationPolicyReconciler) cleanUpChildObjects(plc policyv1.Configu
 		// determine whether object should be deleted
 		needsDelete := false
 
-		existing, _ := getObject(
+		existing, err := getObject(
 			namespaced,
 			object.Object.Metadata.Namespace,
 			object.Object.Metadata.Name,
 			mapping.Resource,
 			r.TargetK8sDynamicClient,
 		)
+		if err != nil {
+			log.Error(err, "Failed to get child object")
+
+			deletionFailures = append(deletionFailures, gvk.String()+fmt.Sprintf(` "%s" in namespace %s`,
+				object.Object.Metadata.Name, object.Object.Metadata.Namespace))
+
+			continue
+		}
 
 		// object does not exist, no deletion logic needed
 		if existing == nil {
@@ -555,7 +563,7 @@ func (r *ConfigurationPolicyReconciler) cleanUpChildObjects(plc policyv1.Configu
 			// if object has already been deleted and is stuck, no need to redo delete request
 			_, deletionTimeFound, _ := unstructured.NestedString(existing.Object, "metadata", "deletionTimestamp")
 			if deletionTimeFound {
-				log.Error(err, "Error: tried to delete object, but delete is hanging")
+				log.Error(fmt.Errorf("tried to delete object, but delete is hanging"), "Error")
 
 				deletionFailures = append(deletionFailures, gvk.String()+fmt.Sprintf(` "%s" in namespace %s`,
 					object.Object.Metadata.Name, object.Object.Metadata.Namespace))
@@ -2099,7 +2107,7 @@ func getObject(
 			return nil, nil
 		}
 
-		objLog.Error(err, "Could not retrieve object from the API server")
+		objLog.V(2).Error(err, "Could not retrieve object from the API server")
 
 		return nil, err
 	}
@@ -2693,7 +2701,7 @@ func (r *ConfigurationPolicyReconciler) addForUpdate(policy *policyv1.Configurat
 	policy.Status.LastEvaluated = time.Now().UTC().Format(time.RFC3339)
 	policy.Status.LastEvaluatedGeneration = policy.Generation
 
-	_, err := r.updatePolicyStatus(policy, sendEvent)
+	err := r.updatePolicyStatus(policy, sendEvent)
 	policyLog := log.WithValues("name", policy.Name, "namespace", policy.Namespace)
 
 	if k8serrors.IsConflict(err) {
@@ -2715,14 +2723,14 @@ func (r *ConfigurationPolicyReconciler) addForUpdate(policy *policyv1.Configurat
 func (r *ConfigurationPolicyReconciler) updatePolicyStatus(
 	policy *policyv1.ConfigurationPolicy,
 	sendEvent bool,
-) (*policyv1.ConfigurationPolicy, error) {
+) error {
 	if sendEvent {
 		log.V(1).Info("Sending parent policy compliance event")
 
 		// If the compliance event can't be created, then don't update the ConfigurationPolicy
 		// status. As long as that hasn't been updated, everything will be retried next loop.
 		if err := r.sendComplianceEvent(policy); err != nil {
-			return policy, err
+			return err
 		}
 	}
 
@@ -2732,7 +2740,7 @@ func (r *ConfigurationPolicyReconciler) updatePolicyStatus(
 
 	err := r.Status().Update(context.TODO(), policy)
 	if err != nil {
-		return policy, err
+		return err
 	}
 
 	if sendEvent {
@@ -2742,7 +2750,7 @@ func (r *ConfigurationPolicyReconciler) updatePolicyStatus(
 			fmt.Sprintf("Policy status is: %v", policy.Status.ComplianceState))
 	}
 
-	return nil, nil
+	return nil
 }
 
 func (r *ConfigurationPolicyReconciler) sendComplianceEvent(instance *policyv1.ConfigurationPolicy) error {

--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -2738,9 +2738,27 @@ func (r *ConfigurationPolicyReconciler) updatePolicyStatus(
 		"Updating configurationPolicy status", "status", policy.Status.ComplianceState, "policy", policy.GetName(),
 	)
 
-	err := r.Status().Update(context.TODO(), policy)
-	if err != nil {
-		return err
+	updatedStatus := policy.Status
+
+	maxRetries := 3
+	for i := 1; i <= maxRetries; i++ {
+		err := r.Get(context.TODO(), types.NamespacedName{Namespace: policy.Namespace, Name: policy.Name}, policy)
+		if err != nil {
+			log.Info(fmt.Sprintf("Failed to refresh policy; using previously fetched version: %s", err))
+		} else {
+			policy.Status = updatedStatus
+		}
+
+		err = r.Status().Update(context.TODO(), policy)
+		if err != nil {
+			if i == maxRetries {
+				return err
+			}
+
+			log.Info(fmt.Sprintf("Failed to update policy status. Retrying (attempt %d/%d): %s", i, maxRetries, err))
+		} else {
+			break
+		}
 	}
 
 	if sendEvent {

--- a/test/e2e/case20_delete_objects_test.go
+++ b/test/e2e/case20_delete_objects_test.go
@@ -609,7 +609,7 @@ var _ = Describe("Test objects are not deleted when the CRD is removed", Ordered
 	})
 })
 
-var _ = Describe("Clean up old object when configuraionpolicy is changed", Ordered, func() {
+var _ = Describe("Clean up old object when configurationpolicy is changed", Ordered, func() {
 	const (
 		oldPodName             string = "case29-name-changed-pod"
 		newPodName             string = "case29-name-changed-new"


### PR DESCRIPTION
Manual cherry-pick:
- https://github.com/stolostron/config-policy-controller/pull/467
- https://github.com/stolostron/config-policy-controller/pull/470

The refetch was the goal, but it had a partial dependency on the error handling which wasn't a large PR so I've included both commits in their entirety.

ref: https://issues.redhat.com/browse/ACM-4885