### PR TITLE
[2.7 cherry-pick] Adjust CompliancyDetails array properly

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -467,7 +467,7 @@ func (r *ConfigurationPolicyReconciler) getObjectTemplateDetails(
 				reason := "namespaceSelector error"
 				msg := fmt.Sprintf(
 					"%s: %s", errMsg, err.Error())
-				statusChanged := addConditionToStatus(&plc, 0, false, reason, msg)
+				statusChanged := addConditionToStatus(&plc, -1, false, reason, msg)
 				if statusChanged {
 					r.Recorder.Event(
 						&plc,
@@ -700,7 +700,7 @@ func (r *ConfigurationPolicyReconciler) handleObjectTemplates(plc policyv1.Confi
 	if validationErr != "" {
 		message := validationErr
 		log.Info(message)
-		statusChanged := addConditionToStatus(&plc, 0, false, "Invalid spec", message)
+		statusChanged := addConditionToStatus(&plc, -1, false, "Invalid spec", message)
 
 		if statusChanged {
 			r.Recorder.Event(&plc, eventWarning,
@@ -770,7 +770,7 @@ func (r *ConfigurationPolicyReconciler) handleObjectTemplates(plc policyv1.Confi
 
 				statusChanged := addConditionToStatus(
 					&plc,
-					0,
+					-1,
 					false,
 					reasonCleanupError,
 					"Failed to delete objects: "+strings.Join(failures, ", "))
@@ -809,7 +809,7 @@ func (r *ConfigurationPolicyReconciler) handleObjectTemplates(plc policyv1.Confi
 			reason = "Error processing template"
 		}
 
-		statusChanged := addConditionToStatus(&plc, 0, false, reason, msg)
+		statusChanged := addConditionToStatus(&plc, -1, false, reason, msg)
 		if statusChanged {
 			parentStatusUpdateNeeded = true
 
@@ -1035,6 +1035,12 @@ func (r *ConfigurationPolicyReconciler) handleObjectTemplates(plc policyv1.Confi
 
 	templateObjs, selectedNamespaces, objTmplStatusChangeNeeded, err = r.getObjectTemplateDetails(plc)
 
+	// Set the CompliancyDetails array length accordingly in case the number of
+	// object-templates was reduced (the status update will handle if it's longer)
+	if len(templateObjs) < len(plc.Status.CompliancyDetails) {
+		plc.Status.CompliancyDetails = plc.Status.CompliancyDetails[:len(templateObjs)]
+	}
+
 	if objTmplStatusChangeNeeded {
 		parentStatusUpdateNeeded = true
 	}
@@ -1052,7 +1058,7 @@ func (r *ConfigurationPolicyReconciler) handleObjectTemplates(plc policyv1.Confi
 		msg := fmt.Sprintf("%v contains no object templates to check, and thus has no violations",
 			plc.GetName())
 
-		statusUpdateNeeded := addConditionToStatus(&plc, 0, true, reason, msg)
+		statusUpdateNeeded := addConditionToStatus(&plc, -1, true, reason, msg)
 
 		if statusUpdateNeeded {
 			eventType := eventNormal
@@ -1257,6 +1263,7 @@ func (r *ConfigurationPolicyReconciler) sortRelatedObjectsAndUpdate(
 }
 
 // helper function that appends a condition (violation or compliant) to the status of a configurationpolicy
+// Set the index to -1 to signal that the status should be cleared.
 func addConditionToStatus(
 	plc *policyv1.ConfigurationPolicy, index int, compliant bool, reason string, message string,
 ) (updateNeeded bool) {
@@ -1293,6 +1300,15 @@ func addConditionToStatus(
 		cond.Message += fmt.Sprintf(". %s.", msg)
 	}
 
+	// Set a boolean to clear the details array if the index is -1, but set
+	// the index to zero to determine whether a status update is required
+	clearStatus := false
+
+	if index == -1 {
+		clearStatus = true
+		index = 0
+	}
+
 	if len(plc.Status.CompliancyDetails) <= index {
 		plc.Status.CompliancyDetails = append(plc.Status.CompliancyDetails, policyv1.TemplateStatus{
 			ComplianceState: complianceState,
@@ -1311,6 +1327,11 @@ func addConditionToStatus(
 		conditions := AppendCondition(plc.Status.CompliancyDetails[index].Conditions, cond, "", false)
 		plc.Status.CompliancyDetails[index].Conditions = conditions
 		updateNeeded = true
+	}
+
+	// Clear the details array if the index provided was -1
+	if clearStatus {
+		plc.Status.CompliancyDetails = plc.Status.CompliancyDetails[0:1]
 	}
 
 	if updateNeeded {

--- a/test/resources/case30_multiline_templatization/case30_configmaps.yaml
+++ b/test/resources/case30_multiline_templatization/case30_configmaps.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: 30config1
+  labels:
+    testcase: "30"
 data:
   name: testvalue1
 ---
@@ -9,5 +11,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: 30config2
+  labels:
+    testcase: "30"
 data:
   name: testvalue2

--- a/test/resources/case30_multiline_templatization/case30_policy.yaml
+++ b/test/resources/case30_multiline_templatization/case30_policy.yaml
@@ -6,7 +6,8 @@ spec:
   remediationAction: enforce
   severity: low
   object-templates-raw: |
-    {{ range (lookup "v1" "ConfigMap" "default" "" "testcase=30").items }}
+    {{ range (lookup "v1" "ConfigMap" "default" "").items }}
+    {{- if and .metadata.labels .metadata.labels.testcase (eq .metadata.labels.testcase "30") }}
       - complianceType: musthave
         objectDefinition:
           apiVersion: v1
@@ -16,4 +17,5 @@ spec:
             namespace: default
           data:
             extraData: exists!
+    {{- end }}
     {{ end }}

--- a/test/resources/case30_multiline_templatization/case30_policy.yaml
+++ b/test/resources/case30_multiline_templatization/case30_policy.yaml
@@ -6,7 +6,7 @@ spec:
   remediationAction: enforce
   severity: low
   object-templates-raw: |
-    {{ range (lookup "v1" "ConfigMap" "default" "").items }}
+    {{ range (lookup "v1" "ConfigMap" "default" "" "testcase=30").items }}
       - complianceType: musthave
         objectDefinition:
           apiVersion: v1

--- a/test/resources/case30_multiline_templatization/case30_unterminated.yaml
+++ b/test/resources/case30_multiline_templatization/case30_unterminated.yaml
@@ -1,22 +1,21 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: policy-pod-create-unterminated
+  name: case30-configpolicy
 spec:
   remediationAction: enforce
   namespaceSelector:
     exclude: ["kube-*"]
     include: ["default"]
-  object-templates-raw: |
-    - complianceType: musthave
-      objectDefinition:
-        apiVersion: v1
-        kind: Pod
-        metadata:
-          name: '{{'
-        spec:
-          containers:
-            - image: nginx:1.7.9
-              name: nginx
-              ports:
-                - containerPort: 80
+  object-templates-raw:  |
+    {{ range (lookup "v1" "ConfigMap" "default" "" "testcase=30").items }}
+      - complianceType: musthave
+        objectDefinition:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: '{{'
+            namespace: default
+          data:
+            extraData: exists!
+    {{ end }}

--- a/test/resources/case30_multiline_templatization/case30_unterminated.yaml
+++ b/test/resources/case30_multiline_templatization/case30_unterminated.yaml
@@ -8,7 +8,8 @@ spec:
     exclude: ["kube-*"]
     include: ["default"]
   object-templates-raw:  |
-    {{ range (lookup "v1" "ConfigMap" "default" "" "testcase=30").items }}
+    {{ range (lookup "v1" "ConfigMap" "default" "").items }}
+    {{- if and .metadata.labels .metadata.labels.testcase (eq .metadata.labels.testcase "30") }}
       - complianceType: musthave
         objectDefinition:
           apiVersion: v1
@@ -18,4 +19,5 @@ spec:
             namespace: default
           data:
             extraData: exists!
+    {{- end }}
     {{ end }}


### PR DESCRIPTION
This is cherry-picked to address https://issues.redhat.com/browse/ACM-6042.

- Clear compliancyDetails on policy-wide errors
- Reduce the length of the array if the number of object-templates is lower

ref: https://issues.redhat.com/browse/ACM-5512
Signed-off-by: Dale Haiducek <19750917+dhaiducek@users.noreply.github.com>
(cherry picked from commit 9b8a98f2a3fd3088576885f825a5e4a5251f6597)