### PR TITLE
Revert "Revert commits not wanted in 2.7.5"

### DIFF
--- a/controllers/configurationpolicy_utils.go
+++ b/controllers/configurationpolicy_utils.go
@@ -114,20 +114,30 @@ func equalObjWithSort(mergedObj interface{}, oldObj interface{}) (areEqual bool)
 		// this includes the case where oldObj is nil
 		return false
 	case []interface{}:
+		if len(mergedObj) == 0 && oldObj == nil {
+			return true
+		}
+
 		if oldObjList, ok := oldObj.([]interface{}); ok {
 			return checkListsMatch(mergedObj, oldObjList)
 		}
 
 		return false
-	default:
-		// NOTE: when type is string, int, bool
-		var oVal interface{}
-
+	default: // when mergedObj's type is string, int, bool, or nil
 		if oldObj == nil && mergedObj != nil {
+			// compare the zero value of mergedObj's type to mergedObj
 			ref := reflect.ValueOf(mergedObj)
-			oVal = reflect.Zero(ref.Type()).Interface()
+			zero := reflect.Zero(ref.Type()).Interface()
 
-			return fmt.Sprint(oVal) == fmt.Sprint(mergedObj)
+			return fmt.Sprint(zero) == fmt.Sprint(mergedObj)
+		}
+
+		if mergedObj == nil && oldObj != nil {
+			// compare the zero value of oldObj's type to oldObj
+			ref := reflect.ValueOf(oldObj)
+			zero := reflect.Zero(ref.Type()).Interface()
+
+			return fmt.Sprint(zero) == fmt.Sprint(oldObj)
 		}
 
 		if !reflect.DeepEqual(fmt.Sprint(mergedObj), fmt.Sprint(oldObj)) {

--- a/test/e2e/case15_event_format_test.go
+++ b/test/e2e/case15_event_format_test.go
@@ -36,21 +36,8 @@ const (
 
 var _ = Describe("Testing compliance event formatting", func() {
 	It("Records the right events for a policy that is always compliant", func() {
-		By("Creating parent policy " + case15AlwaysCompliantParentName + " on " + testNamespace)
-		utils.Kubectl("apply", "-f", case15AlwaysCompliantParentYaml, "-n", testNamespace)
-		parent := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy,
-			case15AlwaysCompliantParentName, testNamespace, true, defaultTimeoutSeconds)
-		Expect(parent).NotTo(BeNil())
-
-		By("Creating compliant policy " + case15AlwaysCompliantName + " on " + testNamespace + " with parent " +
-			case15AlwaysCompliantParentName)
-		plcDef := utils.ParseYaml(case15AlwaysCompliantYaml)
-		ownerRefs := plcDef.GetOwnerReferences()
-		ownerRefs[0].UID = parent.GetUID()
-		plcDef.SetOwnerReferences(ownerRefs)
-		_, err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).
-			Create(context.TODO(), plcDef, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		createConfigPolicyWithParent(case15AlwaysCompliantParentYaml, case15AlwaysCompliantParentName,
+			case15AlwaysCompliantYaml)
 
 		plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
 			case15AlwaysCompliantName, testNamespace, true, defaultTimeoutSeconds)
@@ -81,21 +68,8 @@ var _ = Describe("Testing compliance event formatting", func() {
 		Expect(nonCompParentEvents).To(BeEmpty())
 	})
 	It("Records the right events for a policy that is never compliant", func() {
-		By("Creating parent policy " + case15NeverCompliantParentName + " on " + testNamespace)
-		utils.Kubectl("apply", "-f", case15NeverCompliantParentYaml, "-n", testNamespace)
-		parent := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy,
-			case15NeverCompliantParentName, testNamespace, true, defaultTimeoutSeconds)
-		Expect(parent).NotTo(BeNil())
-
-		By("Creating noncompliant policy " + case15NeverCompliantName + " on " + testNamespace + " with parent " +
-			case15NeverCompliantParentName)
-		plcDef := utils.ParseYaml(case15NeverCompliantYaml)
-		ownerRefs := plcDef.GetOwnerReferences()
-		ownerRefs[0].UID = parent.GetUID()
-		plcDef.SetOwnerReferences(ownerRefs)
-		_, err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).
-			Create(context.TODO(), plcDef, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		createConfigPolicyWithParent(case15NeverCompliantParentYaml, case15NeverCompliantParentName,
+			case15NeverCompliantYaml)
 
 		plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
 			case15NeverCompliantName, testNamespace, true, defaultTimeoutSeconds)
@@ -126,21 +100,8 @@ var _ = Describe("Testing compliance event formatting", func() {
 		Expect(nonCompParentEvents).NotTo(BeEmpty())
 	})
 	It("Records events for a policy that becomes compliant", func() {
-		By("Creating parent policy " + case15BecomesCompliantParentName + " on " + testNamespace)
-		utils.Kubectl("apply", "-f", case15BecomesCompliantParentYaml, "-n", testNamespace)
-		parent := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy,
-			case15BecomesCompliantParentName, testNamespace, true, defaultTimeoutSeconds)
-		Expect(parent).NotTo(BeNil())
-
-		By("Creating noncompliant policy " + case15BecomesCompliantName + " on " + testNamespace + " with parent " +
-			case15BecomesCompliantParentName)
-		plcDef := utils.ParseYaml(case15BecomesCompliantYaml)
-		ownerRefs := plcDef.GetOwnerReferences()
-		ownerRefs[0].UID = parent.GetUID()
-		plcDef.SetOwnerReferences(ownerRefs)
-		_, err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).
-			Create(context.TODO(), plcDef, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		createConfigPolicyWithParent(case15BecomesCompliantParentYaml, case15BecomesCompliantParentName,
+			case15BecomesCompliantYaml)
 
 		plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
 			case15BecomesCompliantName, testNamespace, true, defaultTimeoutSeconds)
@@ -171,21 +132,8 @@ var _ = Describe("Testing compliance event formatting", func() {
 		Expect(compParentEvents).NotTo(BeEmpty())
 	})
 	It("Records events for a policy that becomes noncompliant", func() {
-		By("Creating parent policy " + case15BecomesNonCompliantParentName + " on " + testNamespace)
-		utils.Kubectl("apply", "-f", case15BecomesNonCompliantParentYaml, "-n", testNamespace)
-		parent := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy,
-			case15BecomesNonCompliantParentName, testNamespace, true, defaultTimeoutSeconds)
-		Expect(parent).NotTo(BeNil())
-
-		By("Creating compliant policy " + case15BecomesNonCompliantName + " on " + testNamespace + " with parent " +
-			case15BecomesNonCompliantParentName)
-		plcDef := utils.ParseYaml(case15BecomesNonCompliantYaml)
-		ownerRefs := plcDef.GetOwnerReferences()
-		ownerRefs[0].UID = parent.GetUID()
-		plcDef.SetOwnerReferences(ownerRefs)
-		_, err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).
-			Create(context.TODO(), plcDef, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		createConfigPolicyWithParent(case15BecomesNonCompliantParentYaml, case15BecomesNonCompliantParentName,
+			case15BecomesNonCompliantYaml)
 
 		plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
 			case15BecomesNonCompliantName, testNamespace, true, defaultTimeoutSeconds)

--- a/test/e2e/case17_evaluation_interval_test.go
+++ b/test/e2e/case17_evaluation_interval_test.go
@@ -29,26 +29,7 @@ const (
 
 var _ = Describe("Test evaluation interval", func() {
 	It("Verifies that status.lastEvaluated is properly set", func() {
-		By("Creating the parent policy " + case17ParentPolicyName + " on the managed cluster")
-		utils.Kubectl("apply", "-f", case17ParentPolicy, "-n", testNamespace)
-		parent := utils.GetWithTimeout(clientManagedDynamic,
-			gvrPolicy,
-			case17ParentPolicyName,
-			testNamespace,
-			true,
-			defaultTimeoutSeconds,
-		)
-		Expect(parent).NotTo(BeNil())
-
-		By("Creating " + case17PolicyName + " on the managed cluster")
-		plcDef := utils.ParseYaml(case17Policy)
-		ownerRefs := plcDef.GetOwnerReferences()
-		ownerRefs[0].UID = parent.GetUID()
-		plcDef.SetOwnerReferences(ownerRefs)
-		_, err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).Create(
-			context.TODO(), plcDef, v1.CreateOptions{},
-		)
-		Expect(err).ToNot(HaveOccurred())
+		createConfigPolicyWithParent(case17ParentPolicy, case17ParentPolicyName, case17Policy)
 
 		By("Getting status.lastEvaluated")
 		var managedPlc *unstructured.Unstructured

--- a/test/e2e/case20_delete_objects_test.go
+++ b/test/e2e/case20_delete_objects_test.go
@@ -609,7 +609,7 @@ var _ = Describe("Test objects are not deleted when the CRD is removed", Ordered
 	})
 })
 
-var _ = Describe("Clean up old object when configuraionpolicy is changed", Ordered, func() {
+var _ = Describe("Clean up old object when configurationpolicy is changed", Ordered, func() {
 	const (
 		oldPodName             string = "case20-name-changed-pod"
 		newPodName             string = "case20-name-changed-new"

--- a/test/e2e/case21_alternative_kubeconfig_test.go
+++ b/test/e2e/case21_alternative_kubeconfig_test.go
@@ -58,20 +58,7 @@ var _ = Describe("Test an alternative kubeconfig for policy evaluation", Ordered
 	})
 
 	It("should create the namespace using the alternative kubeconfig", func() {
-		By("Creating parent policy " + parentPolicyName + " on " + testNamespace)
-		utils.Kubectl("apply", "-f", parentPolicyYAML, "-n", testNamespace)
-		parent := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy,
-			parentPolicyName, testNamespace, true, defaultTimeoutSeconds)
-		Expect(parent).NotTo(BeNil())
-
-		By("Creating the " + policyName + " policy")
-		plcDef := utils.ParseYaml(policyYAML)
-		ownerRefs := plcDef.GetOwnerReferences()
-		ownerRefs[0].UID = parent.GetUID()
-		plcDef.SetOwnerReferences(ownerRefs)
-		_, err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).
-			Create(context.TODO(), plcDef, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
+		createConfigPolicyWithParent(parentPolicyYAML, parentPolicyName, policyYAML)
 
 		By("Verifying that the " + policyName + " policy is compliant")
 		Eventually(func() interface{} {
@@ -83,7 +70,7 @@ var _ = Describe("Test an alternative kubeconfig for policy evaluation", Ordered
 		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 
 		By("Verifying that the " + policyName + " was created using the alternative kubeconfig")
-		_, err = targetK8sClient.CoreV1().Namespaces().Get(context.TODO(), namespaceName, metav1.GetOptions{})
+		_, err := targetK8sClient.CoreV1().Namespaces().Get(context.TODO(), namespaceName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verifying that a compliance event was created on the parent policy")

--- a/test/e2e/case31_policy_history_test.go
+++ b/test/e2e/case31_policy_history_test.go
@@ -5,7 +5,6 @@ package e2e
 
 import (
 	"context"
-	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -14,207 +13,168 @@ import (
 	"open-cluster-management.io/config-policy-controller/test/utils"
 )
 
-const (
-	case31Policy                 = "../resources/case31_policy_history/pod-policy.yaml"
-	case31ConfigPolicy           = "../resources/case31_policy_history/pod-config-policy.yaml"
-	case31PolicyName             = "test-policy-security"
-	case31ConfigPolicyName       = "config-policy-pod"
-	case31PolicyNumber           = "../resources/case31_policy_history/pod-policy-number.yaml"
-	case31ConfigPolicyNumber     = "../resources/case31_policy_history/pod-config-policy-number.yaml"
-	case31PolicyNumberName       = "test-policy-security-number"
-	case31ConfigPolicyNumberName = "config-policy-pod-number"
-)
+var _ = Describe("Test policy history messages when KubeAPI omits values in the returned object", Ordered, func() {
+	doHistoryTest := func(policyName, configPolicyName string) {
+		By("Waiting until the policy is initially compliant")
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				configPolicyName, testNamespace, true, defaultTimeoutSeconds)
 
-var _ = Describe("Test policy history message when KubeAPI return "+
-	"omits values in the returned object", Ordered, func() {
-	Describe("status toggling should not be generated When Policy include default value,", Ordered, func() {
-		It("creates the policyconfiguration "+case31Policy, func() {
-			utils.Kubectl("apply", "-f", case31Policy, "-n", "managed")
-		})
+			return utils.GetComplianceState(managedPlc)
+		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 
-		It("verifies the policy "+case31PolicyName+" in "+testNamespace, func() {
-			By("bind policy and configurationpolicy")
-			parent := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy,
-				case31PolicyName, testNamespace, true, defaultTimeoutSeconds)
-			Expect(parent).NotTo(BeNil())
+		By("Checking the events on the configuration policy")
+		Consistently(func() int {
+			eventlen := len(utils.GetMatchingEvents(clientManaged, testNamespace,
+				configPolicyName, configPolicyName, "NonCompliant;", defaultTimeoutSeconds))
 
-			plcDef := utils.ParseYaml(case31ConfigPolicy)
-			ownerRefs := plcDef.GetOwnerReferences()
-			ownerRefs[0].UID = parent.GetUID()
-			plcDef.SetOwnerReferences(ownerRefs)
-			_, err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).
-				Create(context.TODO(), plcDef, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			return eventlen
+		}, 30, 5).Should(BeNumerically("<", 2))
 
-			By("check configurationpolicy exist")
-			plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
-				case31ConfigPolicyName, testNamespace, true, defaultTimeoutSeconds)
-			Expect(plc).NotTo(BeNil())
-		})
+		By("Checking the events on the parent policy")
+		// NOTE: pick policy event, these event's reason include ConfigPolicyName
+		Consistently(func() int {
+			eventlen := len(utils.GetMatchingEvents(clientManaged, testNamespace,
+				policyName, configPolicyName, "NonCompliant;", defaultTimeoutSeconds))
 
-		It("check history toggling", func() {
-			By("wait until pod is up")
-			Eventually(func() interface{} {
-				managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
-					case31ConfigPolicyName, testNamespace, true, defaultTimeoutSeconds)
+			return eventlen
+		}, 30, 5).Should(BeNumerically("<", 3))
+	}
 
-				return utils.GetComplianceState(managedPlc)
-			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+	const (
+		rsrcPath = "../resources/case31_policy_history/"
+	)
 
-			By("check events")
-			Consistently(func() int {
-				eventlen := len(utils.GetMatchingEvents(clientManaged, testNamespace,
-					case31ConfigPolicyName, case31ConfigPolicyName, "NonCompliant;", defaultTimeoutSeconds))
-
-				return eventlen
-			}, 30, 5).Should(BeNumerically("<", 2))
-
-			Consistently(func() int {
-				eventlen := len(utils.GetMatchingEvents(clientManaged, testNamespace,
-					case31PolicyName, case31ConfigPolicyName, "NonCompliant;", defaultTimeoutSeconds))
-
-				return eventlen
-			}, 30, 5).Should(BeNumerically("<", 3))
-		})
-		AfterAll(func() {
-			utils.Kubectl("delete", "policy", case31PolicyName, "-n",
-				"managed", "--ignore-not-found")
-			configlPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
-				case31ConfigPolicyName, "managed", false, defaultTimeoutSeconds,
-			)
-			utils.Kubectl("delete", "event",
-				"--field-selector=involvedObject.name="+case31PolicyName, "-n", "managed")
-			utils.Kubectl("delete", "event",
-				"--field-selector=involvedObject.name="+case31ConfigPolicyName, "-n", "managed")
-			ExpectWithOffset(1, configlPlc).To(BeNil())
-		})
-	})
-	Describe("status should not toggle When Policy include default value of number", Ordered, func() {
-		It("creates the policyconfiguration "+case31PolicyNumber, func() {
-			utils.Kubectl("apply", "-f", case31PolicyNumber, "-n", "managed")
-		})
-
-		It("verifies the policy "+case31PolicyNumberName+" in "+testNamespace, func() {
-			By("bind policy and configurationpolicy")
-			parent := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy,
-				case31PolicyNumberName, testNamespace, true, defaultTimeoutSeconds)
-			Expect(parent).NotTo(BeNil())
-
-			plcDef := utils.ParseYaml(case31ConfigPolicyNumber)
-			ownerRefs := plcDef.GetOwnerReferences()
-			ownerRefs[0].UID = parent.GetUID()
-			plcDef.SetOwnerReferences(ownerRefs)
-			_, err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).
-				Create(context.TODO(), plcDef, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			By("check configurationpolicy exist")
-			plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
-				case31ConfigPolicyNumberName, testNamespace, true, defaultTimeoutSeconds)
-			Expect(plc).NotTo(BeNil())
-		})
-
-		It("check history toggling", func() {
-			By("wait until pod is up")
-			Eventually(func() interface{} {
-				managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
-					case31ConfigPolicyNumberName, testNamespace, true, defaultTimeoutSeconds)
-
-				return utils.GetComplianceState(managedPlc)
-			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
-
-			By("check events")
-			Consistently(func() int {
-				eventLen := len(utils.GetMatchingEvents(clientManaged, testNamespace, case31ConfigPolicyNumberName,
-					case31ConfigPolicyNumberName, "NonCompliant;", defaultTimeoutSeconds))
-
-				return eventLen
-			}, 30, 5).Should(BeNumerically("<", 2))
-
-			// NOTE: pick policy event, these event's reason include ConfigPolicyName
-			Consistently(func() int {
-				eventLen := len(utils.GetMatchingEvents(clientManaged, testNamespace,
-					case31PolicyNumberName, case31ConfigPolicyNumberName, "NonCompliant;", defaultTimeoutSeconds))
-
-				return eventLen
-			}, 30, 5).Should(BeNumerically("<", 3))
-		})
-		AfterAll(func() {
-			utils.Kubectl("delete", "policy", case31PolicyNumberName, "-n",
-				"managed", "--ignore-not-found")
-			configlPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
-				case31ConfigPolicyName, "managed", false, defaultTimeoutSeconds,
-			)
-			utils.Kubectl("delete", "event",
-				"--field-selector=involvedObject.name="+case31PolicyNumberName, "-n", "managed")
-			utils.Kubectl("delete", "event",
-				"--field-selector=involvedObject.name="+case31ConfigPolicyNumberName, "-n", "managed")
-
-			ExpectWithOffset(1, configlPlc).To(BeNil())
-		})
-	})
-	Describe("policy message should not be truncated", func() {
+	Describe("status should not toggle when a boolean field might be omitted", Ordered, func() {
 		const (
-			case31LMPolicy           = "../resources/case31_policy_history/long-message-policy.yaml"
-			case31LMConfigPolicy     = "../resources/case31_policy_history/long-message-config-policy.yaml"
-			case31LMPolicyName       = "long-message-policy"
-			case31LMConfigPolicyName = "long-message-config-policy"
-			namespacePrefix          = "innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt"
+			policyYAML       = rsrcPath + "pod-policy.yaml"
+			policyName       = "test-policy-security"
+			configPolicyYAML = rsrcPath + "pod-config-policy.yaml"
+			configPolicyName = "config-policy-pod"
 		)
-		It("Test policy message length is over 1024 ", func() {
-			By("Create namespaces")
-			for i := range [15]int{} {
-				utils.Kubectl("create", "ns", namespacePrefix+strconv.Itoa(i+1))
-			}
-			utils.Kubectl("apply", "-f", case31LMPolicy, "-n", "managed")
-			By("bind policy and configurationpolicy")
-			parent := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy,
-				case31LMPolicyName, testNamespace, true, defaultTimeoutSeconds)
-			Expect(parent).NotTo(BeNil())
 
-			plcDef := utils.ParseYaml(case31LMConfigPolicy)
-			ownerRefs := plcDef.GetOwnerReferences()
-			ownerRefs[0].UID = parent.GetUID()
-			plcDef.SetOwnerReferences(ownerRefs)
-			_, err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).
-				Create(context.TODO(), plcDef, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			By("check configurationpolicy exist")
-			Eventually(func() interface{} {
-				plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
-					case31LMConfigPolicyName, testNamespace, true, defaultTimeoutSeconds)
-				compliant := utils.GetComplianceState(plc)
-
-				return compliant
-			}, 30, 5).Should(Equal("NonCompliant"))
-
-			By("check message longer than 1024")
-			Eventually(func() int {
-				event := utils.GetMatchingEvents(clientManaged, testNamespace,
-					case31LMPolicyName, case31LMConfigPolicyName, "NonCompliant", defaultTimeoutSeconds)
-
-				Expect(event).ShouldNot(BeEmpty())
-				message := event[len(event)-1].Message
-
-				return len(message)
-			}, 30, 5).Should(BeNumerically(">", 1024))
+		It("sets up a configuration policy with an omitempty boolean set to false", func() {
+			createConfigPolicyWithParent(policyYAML, policyName, configPolicyYAML)
 		})
+
+		It("checks the policy's history", func() {
+			doHistoryTest(policyName, configPolicyName)
+		})
+
 		AfterAll(func() {
-			utils.Kubectl("delete", "policy", case31LMPolicyName, "-n",
-				"managed", "--ignore-not-found")
+			utils.Kubectl("delete", "policy", policyName, "-n", "managed", "--ignore-not-found")
 			configlPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
-				case31LMPolicyName, "managed", false, defaultTimeoutSeconds,
+				configPolicyName, "managed", false, defaultTimeoutSeconds,
 			)
-			Expect(configlPlc).To(BeNil())
-			utils.Kubectl("delete", "event",
-				"--field-selector=involvedObject.name="+case31LMPolicyName, "-n", "managed")
-			utils.Kubectl("delete", "event",
-				"--field-selector=involvedObject.name="+case31LMConfigPolicy, "-n", "managed")
-			for i := range [15]int{} {
-				utils.Kubectl("delete", "ns", namespacePrefix+strconv.Itoa(i+1),
-					"--ignore-not-found", "--force", "--grace-period=0")
-			}
+			utils.Kubectl("delete", "event", "--field-selector=involvedObject.name="+policyName, "-n", "managed")
+			utils.Kubectl("delete", "event", "--field-selector=involvedObject.name="+configPolicyName, "-n", "managed")
+			ExpectWithOffset(1, configlPlc).To(BeNil())
+		})
+	})
+
+	Describe("status should not toggle when a numerical field might be omitted", Ordered, func() {
+		const (
+			policyYAML       = rsrcPath + "pod-policy-number.yaml"
+			policyName       = "test-policy-security-number"
+			configPolicyYAML = rsrcPath + "pod-config-policy-number.yaml"
+			configPolicyName = "config-policy-pod-number"
+		)
+
+		It("sets up a configuration policy with an omitempty number set to 0", func() {
+			createConfigPolicyWithParent(policyYAML, policyName, configPolicyYAML)
+		})
+
+		It("checks the policy's history", func() {
+			doHistoryTest(policyName, configPolicyName)
+		})
+
+		AfterAll(func() {
+			utils.Kubectl("delete", "policy", policyName, "-n", "managed", "--ignore-not-found")
+			configlPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				configPolicyName, "managed", false, defaultTimeoutSeconds,
+			)
+			utils.Kubectl("delete", "event", "--field-selector=involvedObject.name="+policyName, "-n", "managed")
+			utils.Kubectl("delete", "event", "--field-selector=involvedObject.name="+configPolicyName, "-n", "managed")
+			ExpectWithOffset(1, configlPlc).To(BeNil())
+		})
+	})
+
+	Describe("status should not toggle when an array might be omitted", Ordered, func() {
+		const (
+			policyYAML       = rsrcPath + "rb-policy-emptyarray.yaml"
+			policyName       = "test-policy-security-emptyarray"
+			configPolicyYAML = rsrcPath + "rb-config-policy-emptyarray.yaml"
+			configPolicyName = "config-policy-rb-emptyarray"
+		)
+
+		It("sets up a configuration policy with an omitempty number set to 0", func() {
+			createConfigPolicyWithParent(policyYAML, policyName, configPolicyYAML)
+		})
+
+		It("checks the policy's history", func() {
+			doHistoryTest(policyName, configPolicyName)
+		})
+
+		AfterAll(func() {
+			utils.Kubectl("delete", "policy", policyName, "-n", "managed", "--ignore-not-found")
+			configlPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				configPolicyName, "managed", false, defaultTimeoutSeconds,
+			)
+			utils.Kubectl("delete", "event", "--field-selector=involvedObject.name="+policyName, "-n", "managed")
+			utils.Kubectl("delete", "event", "--field-selector=involvedObject.name="+configPolicyName, "-n", "managed")
+			ExpectWithOffset(1, configlPlc).To(BeNil())
+		})
+	})
+
+	Describe("status should not toggle when a struct might be omitted", Ordered, func() {
+		const (
+			policyYAML       = rsrcPath + "event-policy-emptystruct.yaml"
+			policyName       = "test-policy-security-emptystruct"
+			configPolicyYAML = rsrcPath + "event-config-policy-emptystruct.yaml"
+			configPolicyName = "config-policy-event-emptystruct"
+		)
+
+		It("sets up a configuration policy with struct set to null", func() {
+			createConfigPolicyWithParent(policyYAML, policyName, configPolicyYAML)
+		})
+
+		It("checks the policy's history", func() {
+			doHistoryTest(policyName, configPolicyName)
+		})
+
+		AfterAll(func() {
+			utils.Kubectl("delete", "policy", policyName, "-n", "managed", "--ignore-not-found")
+			configlPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				configPolicyName, "managed", false, defaultTimeoutSeconds,
+			)
+			utils.Kubectl("delete", "event", "--field-selector=involvedObject.name="+policyName, "-n", "managed")
+			utils.Kubectl("delete", "event", "--field-selector=involvedObject.name="+configPolicyName, "-n", "managed")
+			ExpectWithOffset(1, configlPlc).To(BeNil())
 		})
 	})
 })
+
+func createConfigPolicyWithParent(parentPolicyYAML, parentPolicyName, configPolicyYAML string) {
+	By("Creating the parent policy")
+	utils.Kubectl("apply", "-f", parentPolicyYAML, "-n", testNamespace)
+	parent := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy,
+		parentPolicyName, testNamespace, true, defaultTimeoutSeconds)
+	Expect(parent).NotTo(BeNil())
+
+	plcDef := utils.ParseYaml(configPolicyYAML)
+	ownerRefs := plcDef.GetOwnerReferences()
+	ownerRefs[0].UID = parent.GetUID()
+	plcDef.SetOwnerReferences(ownerRefs)
+
+	By("Creating the configuration policy with the owner reference")
+
+	_, err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).
+		Create(context.TODO(), plcDef, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Verifying the configuration policy exists")
+
+	plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+		plcDef.GetName(), testNamespace, true, defaultTimeoutSeconds)
+	Expect(plc).NotTo(BeNil())
+}

--- a/test/resources/case31_policy_history/event-config-policy-emptystruct.yaml
+++ b/test/resources/case31_policy_history/event-config-policy-emptystruct.yaml
@@ -1,0 +1,39 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: config-policy-event-emptystruct
+  labels:
+    policy.open-cluster-management.io/policy: test-policy-security
+  ownerReferences:
+  - apiVersion: policy.open-cluster-management.io/v1
+    blockOwnerDeletion: false
+    controller: true
+    kind: Policy
+    name: test-policy-security-emptystruct
+    uid: 08bae967-4262-498a-84e9-d1f0e321b41e
+spec:
+  pruneObjectBehavior: DeleteAll  
+  remediationAction: enforce
+  namespaceSelector:
+    exclude:
+      - kube-public
+    include:
+      - default
+      - kube-system
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        action: DidTheThing
+        apiVersion: events.k8s.io/v1
+        eventTime: 2023-04-27T14:37:36.721589Z
+        kind: Event
+        metadata:
+          name: configpol-test-event
+          namespace: kube-system
+        note: Successfully did something
+        reason: Success
+        regarding: null
+        related: null
+        reportingController: ConfigPolicyTester
+        reportingInstance: configpol-history-test
+        type: Normal

--- a/test/resources/case31_policy_history/event-policy-emptystruct.yaml
+++ b/test/resources/case31_policy_history/event-policy-emptystruct.yaml
@@ -1,0 +1,42 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: test-policy-security-emptystruct
+  annotations:
+    policy.open-cluster.management.io/standards: NIST-CSF
+    policy.open-cluster.management.io/categories: PR.PT Protective Technology
+    policy.open-cluster.management.io/controls: PR.PT-3 Least Functionality
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: config-policy-event-emptystruct
+        spec:
+          remediationAction: enforce
+          namespaceSelector:
+            exclude:
+              - kube-public
+            include:
+              - default
+              - kube-system
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                action: DidTheThing
+                apiVersion: events.k8s.io/v1
+                eventTime: 2023-04-27T14:37:36.721589Z
+                kind: Event
+                metadata:
+                  name: configpol-test-event
+                  namespace: kube-system
+                note: Successfully did something
+                reason: Success
+                regarding: null
+                related: null
+                reportingController: ConfigPolicyTester
+                reportingInstance: configpol-history-test
+                type: Normal

--- a/test/resources/case31_policy_history/rb-config-policy-emptyarray.yaml
+++ b/test/resources/case31_policy_history/rb-config-policy-emptyarray.yaml
@@ -1,0 +1,33 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: config-policy-rb-emptyarray
+  labels:
+    policy.open-cluster-management.io/policy: test-policy-security
+  ownerReferences:
+  - apiVersion: policy.open-cluster-management.io/v1
+    blockOwnerDeletion: false
+    controller: true
+    kind: Policy
+    name: test-policy-security-emptyarray
+    uid: 08bae967-4262-498a-84e9-d1f0e321b41e
+spec:
+  pruneObjectBehavior: DeleteAll  
+  remediationAction: enforce
+  namespaceSelector:
+    exclude:
+      - kube-*
+    include:
+      - default
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: case31-empty-binding
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: Role
+          name: case31-imaginary-role
+        subjects: []

--- a/test/resources/case31_policy_history/rb-policy-emptyarray.yaml
+++ b/test/resources/case31_policy_history/rb-policy-emptyarray.yaml
@@ -1,0 +1,36 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: test-policy-security-emptyarray
+  annotations:
+    policy.open-cluster.management.io/standards: NIST-CSF
+    policy.open-cluster.management.io/categories: PR.PT Protective Technology
+    policy.open-cluster.management.io/controls: PR.PT-3 Least Functionality
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: config-policy-rb-emptyarray
+        spec:
+          remediationAction: enforce
+          namespaceSelector:
+            exclude:
+              - kube-*
+            include:
+              - default
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: rbac.authorization.k8s.io/v1
+                kind: RoleBinding
+                metadata:
+                  name: case31-empty-binding
+                roleRef:
+                  apiGroup: rbac.authorization.k8s.io
+                  kind: Role
+                  name: case31-imaginary-role
+                subjects: []


### PR DESCRIPTION
This reverts commit 45040d55b14b0f19461c280348dceb134a4a8328, bringing back:
- "Add refetch before updating status" 084e54d
- "Tweak error handling" f8d5d9c
- "Fix constantly updating objects with a null struct" d704d5f
- "Fix constantly updating objects with an empty list" 3b1204c
- "Use common parent policy creation function" 38fc8ac
- "Add test for possibly omitted array" fb12e14