### PR TITLE
Manual cherry-pick: Enable configuring the controller namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ to learn how to get involved.
 
 ### Steps for deployment
 
-  - Build container image
+  - (optional) Build container image
     ```bash
     make build-images
     ```
@@ -137,21 +137,17 @@ to learn how to get involved.
 
     The controller is deployed to a namespace defined in `KIND_NAMESPACE` and monitors the namepace defined in `WATCH_NAMESPACE` for `ConfigurationPolicy` resources.
 
-    1. Create the deployment namespaces
+    1. Deploy the controller and related resources
        ```bash
-       make create-ns
+       make deploy
        ```
+
        The deployment namespaces are configurable with:
        ```bash
        export KIND_NAMESPACE=''  # (defaults to 'open-cluster-management-agent-addon')
        export WATCH_NAMESPACE=''       # (defaults to 'managed')
        ```
-    2. Deploy the controller and related resources
-       ```bash
-       make deploy
-       ```
-    **NOTE:** Please be aware of the community's [deployment images](https://github.com/stolostron/community#deployment-images) special note.
-
+    **NOTE:** Please be aware of the community's [deployment images](https://github.com/open-cluster-management-io/community#deployment-images) special note.
 
 ### Steps for test
 


### PR DESCRIPTION
The `ClusterRoleBinding` had a hardcoded namespace, preventing the controller from running in a custom namespace.

Signed-off-by: Dale Haiducek <19750917+dhaiducek@users.noreply.github.com>
(cherry picked from commit bc358da92d003d2a35e5f6b01ff8a195d2f0813a)

Cherry-pick of:
- open-cluster-management-io/config-policy-controller#173

Closes #625 