### PR TITLE
[Manual sync] Simplify GitHub Action workflows

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -13,7 +13,6 @@ on:
 defaults:
   run:
     shell: bash
-    working-directory: config-policy-controller
 
 jobs:
   kind-tests:
@@ -33,15 +32,11 @@ jobs:
     steps:
       - name: Checkout Config Policy Controller
         uses: actions/checkout@v4
-        with:
-          path: config-policy-controller
-          fetch-depth: 0 # Fetch all history for all tags and branches
 
       - name: Set up Go
         uses: actions/setup-go@v5
-        id: go
         with:
-          go-version-file: config-policy-controller/go.mod
+          go-version-file: go.mod
 
       - name: Verify modules
         run: |
@@ -123,9 +118,9 @@ jobs:
         with:
           name: artifacts
           path: |
-            config-policy-controller/coverage*.out
-            config-policy-controller/event.json
-            config-policy-controller/gosec.json
+            coverage*.out
+            event.json
+            gosec.json
 
       - name: Debug
         if: ${{ failure() }}


### PR DESCRIPTION
Manual cherry-pick:
- https://github.com/open-cluster-management-io/config-policy-controller/pull/203

Closes #719 

- Removes unnecessary subdirectories in favor of defaults
- Also attempts to resolve the `setup-go` caching warnings.

Signed-off-by: Dale Haiducek <19750917+dhaiducek@users.noreply.github.com>
(cherry picked from commit e08ed0bf7c1754b238cbd0eaca9d3ca30ed70b55)