### PR TITLE
Fix bug where decoding stringdata modified the existing object directly

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -2468,9 +2468,7 @@ func handleSingleKey(
 	}
 
 	if key == "stringData" && existingObj.GetKind() == "Secret" {
-		// override automatic conversion from stringData to data prior to evaluation
-		existingValue = existingObj.UnstructuredContent()["data"]
-
+		// override automatic conversion from stringData to data before evaluation
 		encodedValue, _, err := unstructured.NestedStringMap(existingObj.Object, "data")
 		if err != nil {
 			message := "Error accessing encoded data"
@@ -2478,8 +2476,10 @@ func handleSingleKey(
 			return message, false, mergedValue, false
 		}
 
-		for k, value := range encodedValue {
-			decodedVal, err := base64.StdEncoding.DecodeString(value)
+		decodedValue := make(map[string]interface{}, len(encodedValue))
+
+		for k, encoded := range encodedValue {
+			decoded, err := base64.StdEncoding.DecodeString(encoded)
 			if err != nil {
 				secretName := existingObj.GetName()
 				message := fmt.Sprintf("Error decoding secret: %s", secretName)
@@ -2487,8 +2487,10 @@ func handleSingleKey(
 				return message, false, mergedValue, false
 			}
 
-			existingValue.(map[string]interface{})[k] = string(decodedVal)
+			decodedValue[k] = string(decoded)
 		}
+
+		existingValue = decodedValue
 	}
 
 	// sort objects before checking equality to ensure they're in the same order


### PR DESCRIPTION
Solution: when decoding, operate on a copy of the existing object's data

Ref: https://issues.redhat.com/browse/ACM-10577
Signed-off-by: Jeffrey Luo <jeluo@redhat.com>
(cherry picked from commit 2d10d5372515abbcf8bdd89d371325cf686c98e4)