### PR TITLE
[release-2.10] Relax event requirement for a flaky test

### DIFF
--- a/test/e2e/case38_install_operator_test.go
+++ b/test/e2e/case38_install_operator_test.go
@@ -699,7 +699,7 @@ var _ = Describe("Test installing an operator from OperatorPolicy", Ordered, fun
 						" in the catalog referenced by subscription project-quay-does-not-exist, subscription " +
 						"project-quay-does-not-exist exists",
 				},
-				"constraints not satisfiable: no operators found in package project-quay-does-not-exist",
+				"constraints not satisfiable",
 			)
 
 			// Check if the subscription is still compliant on the operator policy trying to install a valid operator.


### PR DESCRIPTION
When the subscription has a ConstraintsNotSatisfiable condition, the exact content of the message is not always consistent. We have added other things to sort the message better, but it looks like we missed this test which was still assuming a certain part was first.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>
(cherry picked from commit fa5b2358a9c01bc3b09f3e189ef8b2b9dde030d5)

Cherry-pick for:
 - https://issues.redhat.com/browse/ACM-11190