### PR TITLE
[release-2.10] Wait for actual ConstraintsNotSatisfiable reason

### DIFF
--- a/test/e2e/case38_install_operator_test.go
+++ b/test/e2e/case38_install_operator_test.go
@@ -987,12 +987,13 @@ var _ = Describe("Test installing an operator from OperatorPolicy", Ordered, fun
 
 					condType, _, _ := unstructured.NestedString(condMap, "type")
 					if condType == "ResolutionFailed" {
-						return condMap["status"]
+						return condMap["reason"]
 					}
 				}
 
 				return nil
-			}, olmWaitTimeout, 5, ctx).Should(Equal("True"))
+			}, olmWaitTimeout*2, 5, ctx).Should(Equal("ConstraintsNotSatisfiable"))
+
 			check(
 				opPolName,
 				true,


### PR DESCRIPTION
This seemed like a worthwhile fix to bring to 2.10 from https://github.com/open-cluster-management-io/config-policy-controller/pull/235 (Note: the main *feature* from that PR is not coming to this release branch, just one test improvement).