### PR TITLE
Split kind.yaml workflow into parallel jobs

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -15,7 +15,71 @@ defaults:
     shell: bash
 
 jobs:
+  preflight-tests:
+    name: Preflight Tests
+    runs-on: ubuntu-latest
+    env:
+      KIND_VERSION: latest
+      REGISTRY: localhost:5000
+    steps:
+      - name: Checkout Config Policy Controller
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Format, Lint, and Generate
+        run: |
+          go mod verify
+          make fmt
+          git diff --exit-code
+          make lint
+          make generate
+          make generate-operator-yaml
+          git diff --exit-code
+
+      - name: Unit Tests
+        run: |
+          make test-coverage
+
+      - name: Upload Unit Test Coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage_unit
+          path: coverage_unit.out
+
+      - name: Bootstrap K8s KinD Cluster and Deploy Controller
+        run: |
+          make kind-bootstrap-cluster-dev
+          KUBECONFIG=${PWD}/kubeconfig_managed make kind-ensure-sa
+          make build-images
+          KUBECONFIG=${PWD}/kubeconfig_managed_e2e make kind-deploy-controller-dev
+
+      - name: E2E tests that require the controller running in a cluster
+        run: |
+          export GOPATH=$(go env GOPATH)
+          KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-running-in-cluster
+
+      - name: Upload Uninstall Test Coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage_e2e_uninstall
+          path: coverage_e2e_uninstall.out
+      
+      - name: Debug
+        if: ${{ failure() }}
+        run: |
+          make e2e-debug
+
+      - name: Clean up cluster
+        if: ${{ always() }}
+        run: |
+          make kind-delete-cluster
+
   kind-tests:
+    name: KinD tests
     runs-on: ubuntu-latest
     env:
       REGISTRY: localhost:5000
@@ -28,7 +92,6 @@ jobs:
         kind:
           - "minimum"
           - "latest"
-    name: KinD tests
     steps:
       - name: Checkout Config Policy Controller
         uses: actions/checkout@v4
@@ -38,34 +101,11 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Verify modules
-        run: |
-          go mod verify
-
-      - name: Verify format
-        run: |
-          make fmt
-          git diff --exit-code
-          make lint
-
-      - name: Verify deploy/operator.yaml
-        run: |
-          make generate
-          make generate-operator-yaml
-          git diff --exit-code
-
-      - name: Unit and Integration Tests
-        run: |
-          make test
-
       - name: Create K8s KinD Cluster - ${{ matrix.kind }}
         env:
           KIND_VERSION: ${{ matrix.kind }}
         run: |
           make kind-bootstrap-cluster-dev
-
-      - name: Ensure Service Account kubeconfig
-        run: |
           KUBECONFIG=${PWD}/kubeconfig_managed make kind-ensure-sa
 
       - name: E2E Tests
@@ -73,54 +113,12 @@ jobs:
           export GOPATH=$(go env GOPATH)
           KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-coverage
 
-      - name: Create K8s KinD Cluster to simulate hosted mode - ${{ matrix.kind }}
-        env:
-          KIND_VERSION: ${{ matrix.kind }}
-        run: |
-          make kind-additional-cluster
-
-      - name: E2E tests that simulate hosted mode
-        run: |
-          export GOPATH=$(go env GOPATH)
-          KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-hosted-mode-coverage
-
-      - name: Verify Deployment Configuration
-        run: |
-          make build-images
-          KUBECONFIG=${PWD}/kubeconfig_managed_e2e make kind-deploy-controller-dev
-
-      - name: E2E tests that require the controller running in a cluster
-        run: |
-          export GOPATH=$(go env GOPATH)
-          KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-running-in-cluster
-
-      - name: Test Coverage and Report Generation
-        run: |
-          make test-coverage | tee report_unit.json
-          make coverage-verify
-          make gosec-scan
-          cat gosec.json
-
-      - name: Store the GitHub triggering event for the sonarcloud workflow
-        if: |
-          matrix.kind == 'latest' &&
-          github.repository_owner == 'stolostron'
-        run: |
-          cat <<EOF > event.json
-          ${{ toJSON(github.event) }}
-          EOF
-
-      - name: Upload artifacts for the sonarcloud workflow
-        if: |
-          matrix.kind == 'latest' &&
-          github.repository_owner == 'stolostron'
+      - name: Upload E2E Test Coverage
         uses: actions/upload-artifact@v4
+        if: ${{ matrix.kind == 'latest' }}
         with:
-          name: artifacts
-          path: |
-            coverage*.out
-            event.json
-            gosec.json
+          name: coverage_e2e
+          path: coverage_e2e.out
 
       - name: Debug
         if: ${{ failure() }}
@@ -131,3 +129,97 @@ jobs:
         if: ${{ always() }}
         run: |
           make kind-delete-cluster
+
+  hosted-tests:
+    name: Hosted KinD tests
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: localhost:5000
+    strategy:
+      fail-fast: false
+      matrix:
+        # Run tests on minimum and newest supported OCP Kubernetes
+        # The "minimum" tag is set in the Makefile
+        # KinD tags: https://hub.docker.com/r/kindest/node/tags
+        kind:
+          - "minimum"
+          - "latest"
+    steps:
+      - name: Checkout Config Policy Controller
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Create K8s KinD Clusters - ${{ matrix.kind }}
+        env:
+          KIND_VERSION: ${{ matrix.kind }}
+        run: |
+          make kind-bootstrap-cluster-dev
+          KUBECONFIG=${PWD}/kubeconfig_managed make kind-ensure-sa
+          make kind-additional-cluster
+
+      - name: E2E tests that simulate hosted mode
+        run: |
+          export GOPATH=$(go env GOPATH)
+          KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-hosted-mode-coverage
+
+      - name: Upload Hosted Mode Coverage
+        uses: actions/upload-artifact@v4
+        if: ${{ matrix.kind == 'latest' }}
+        with:
+          name: coverage_e2e_hosted_mode
+          path: coverage_e2e_hosted_mode.out
+
+      - name: Debug
+        if: ${{ failure() }}
+        run: |
+          make e2e-debug
+
+      - name: Clean up cluster
+        if: ${{ always() }}
+        run: |
+          make kind-delete-cluster
+
+  coverage-verification:
+    needs: [preflight-tests, kind-tests, hosted-tests]
+    defaults:
+      run:
+        working-directory: '.'
+    name: Test Coverage Verification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Config Policy Controller
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Download Coverage Results
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Test Coverage Verification
+        run: |
+          make coverage-verify
+          make gosec-scan
+          
+          cat gosec.json
+          cat <<EOF > event.json
+          ${{ toJSON(github.event) }}
+          EOF
+      
+      - name: Upload artifacts for the sonarcloud workflow
+        if: ${{ github.repository_owner == 'stolostron' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts
+          path: |
+            coverage*.out
+            event.json
+            gosec.json

--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,7 @@ install-crds:  $(OLM_INSTALLER)
 
 $(OLM_INSTALLER):
 	@echo getting OLM installer
+	mkdir -p $(LOCAL_BIN)
 	curl -L https://github.com/operator-framework/operator-lifecycle-manager/releases/download/$(OLM_VERSION)/install.sh -o $(LOCAL_BIN)/install.sh
 
 install-crds-hosted: export KUBECONFIG=./kubeconfig_managed$(MANAGED_CLUSTER_SUFFIX)_e2e


### PR DESCRIPTION
The hosted mode tests and the "regular" tests were running in series, and each took about 20 minutes. Now they run in parallel in separate jobs, with a new job to merge their coverage data. Some other "quick" checks (like formatting, linting) were also moved to a separate job, which allows the tests to run even if there is a linting issue.

Refs:
 - https://issues.redhat.com/browse/ACM-13032

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>
(cherry picked from commit 8b0aecf8f3dfd6a340a1462ca2ec4432dc4fac1b)

Closes https://github.com/stolostron/config-policy-controller/issues/987