### PR TITLE
Add repository url label to container images

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -37,3 +37,4 @@ LABEL io.k8s.description="The ConfigurationPolicy kind compares the desired obje
     The OperatorPolicy kind determines whether operators deployed on the cluster match the configuration in the policy."
 LABEL com.redhat.component="acm-config-policy-controller-container"
 LABEL io.openshift.tags="data,images"
+LABEL url="https://github.com/stolostron/config-policy-controller"


### PR DESCRIPTION
This pull request adds the repository URL as the 'url' label to container images.

**Related Issue:** https://issues.redhat.com/browse/ACM-23275

**Epic Goal:** All ACM and MCE container images should define the url label pointing to their source repository instead of the generic 'https://www.redhat.com' value.

**Target Branch:** main

**Components affected:** config-policy-controller

**Branch details:** config-policy-controller (revision: main, fast-forwarded to: main)

**Label added:**
- url: https://github.com/stolostron/config-policy-controller

This change improves traceability and helps identify the source repository for each container image, which is especially important for components like kube-rbac-proxy that exist in multiple organizations.